### PR TITLE
add linter/formatter. only apply to iso19115-3 reader content.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,12 +3,17 @@ name: Tests
 on: [push]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+      - run: bundle install
+      - run: bundle exec rubocop
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.1" # Not needed with a .ruby-version file
       - run: bundle install
       - run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ mkmf.log
 /.rake_tasks~
 vendor/
 *.DS_Store
+.vscode/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,19 @@
+AllCops:
+  Include:
+    - lib/adiwg/mdtranslator/readers/iso19115_3/**/*.rb
+    - test/readers/iso19115_3/**/*.rb
+  Exclude:
+    - bin/*
+    - vendor/**/*
+
+Layout/IndentationStyle:
+  EnforcedStyle: spaces
+
+Layout/IndentationWidth:
+  Width: 3 
+
+Naming/ClassAndModuleCamelCase:
+  Enabled: true
+
+Naming/VariableName:
+  EnforcedStyle: camelCase

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
     adiwg-mdcodes (2.10.0)
       json (~> 2.0)
     adiwg-mdjson_schemas (2.9.5)
+    ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
     builder (3.3.0)
@@ -57,6 +58,7 @@ GEM
       addressable (>= 2.4)
     kramdown (2.4.0)
       rexml
+    language_server-protocol (3.17.0.3)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -64,6 +66,10 @@ GEM
     mutex_m (0.2.0)
     nokogiri (1.16.6-arm64-darwin)
       racc (~> 1.4)
+    parallel (1.25.1)
+    parser (3.3.3.0)
+      ast (~> 2.4.1)
+      racc
     public_suffix (5.1.1)
     racc (1.8.0)
     rails-dom-testing (2.2.0)
@@ -73,13 +79,30 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rainbow (3.1.1)
     rake (13.2.1)
+    regexp_parser (2.9.2)
     rexml (3.3.0)
       strscan
+    rubocop (1.64.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
     strscan (3.1.0)
     thor (0.20.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
     uuidtools (2.2.0)
 
 PLATFORMS
@@ -90,6 +113,7 @@ DEPENDENCIES
   bundler (~> 2)
   minitest (~> 5)
   rake (~> 13)
+  rubocop (~> 1.64)
 
 BUNDLED WITH
    2.4.22

--- a/adiwg-mdtranslator.gemspec
+++ b/adiwg-mdtranslator.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
    spec.add_development_dependency "bundler", "~> 2"
    spec.add_development_dependency "rake", "~> 13"
    spec.add_development_dependency "minitest", "~> 5"
+   spec.add_development_dependency "rubocop", "~> 1.64"
 
    spec.add_runtime_dependency "json", "~> 2.0"
    spec.add_runtime_dependency "builder", "~> 3.2"


### PR DESCRIPTION
there's no files to be linted because they're in the [iso reader feature branch](https://github.com/GSA/mdTranslator/tree/feature/iso19115_3-reader). i'm gonna merge datagov into that branch.