### PR TITLE
iso to dcatus properties

### DIFF
--- a/lib/adiwg/mdtranslator/readers/iso19115_3/modules/module_citation.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_3/modules/module_citation.rb
@@ -79,7 +79,7 @@ module ADIWG
 
                   # :identifiers
                   citIds = xCitation.xpath(@@citIdXpath)
-                  hCitation[:identifiers] = citIds.map { |c| Identification.unpack(c, hResponseObj) }
+                  hCitation[:identifiers] = citIds.map { |c| Identification.unpack(c, hResponseObj)[0] }
 
                   # TODO: all these other things...
                   #    edition: nil,

--- a/lib/adiwg/mdtranslator/readers/iso19115_3/modules/module_contact.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_3/modules/module_contact.rb
@@ -31,32 +31,57 @@ module ADIWG
                      return xContact
                   end
 
-                  # :contactType
-                  xContactType = xContact.xpath(@@contactTypeXPath)
-                  hContact[:contactType] = xContactType.empty? ? nil : xContactType[0].text
+                  # :contactType (optional)
+                  # <element minOccurs="0" name="contactType" type="gco:CharacterString_PropertyType"/>
+                  xContactType = xContact.xpath(@@contactTypeXPath)[0]
+                  hContact[:contactType] = xContactType.nil? ? nil : xContactType.text
 
-                  # :contactInstructions
-                  xContactInstructions = xContact.xpath(@@contactInstXPath)
-                  hContact[:contactInstructions] = xContactInstructions.empty? ? nil : xContactInstructions[0].text
+                  # :contactInstructions (optional)
+                  # <element minOccurs="0" name="contactInstructions"
+                  # type="gco:CharacterString_PropertyType">
+                  xContactInstructions = xContact.xpath(@@contactInstXPath)[0]
+                  hContact[:contactInstructions] = xContactInstructions.nil? ? nil : xContactInstructions.text
 
-                  # :hoursOfService
+                  # :hoursOfService (optional)
+                  # <element maxOccurs="unbounded" minOccurs="0" name="hoursOfService"
+                  # type="gco:CharacterString_PropertyType">
                   xContactHOS = xContact.xpath(@@contactHOSXPath)
-                  hContact[:hoursOfService] = xContactHOS.empty? ? nil : xContactHOS[0].text
+                  hContact[:hoursOfService] = xContactHOS.map(&:text).compact
 
-                  # :phones
+                  # :phones (optional)
+                  # <element maxOccurs="unbounded" minOccurs="0" name="phone" type="cit:CI_Telephone_PropertyType">
                   xPhones = xContact.xpath(@@phoneXPath)
                   hContact[:phones] = xPhones.map { |phone| Telephone.unpack(phone, hResponseObj) }
 
-                  # :addresses & eMailList
+                  # :addresses (optional) & eMailList
+                  # <element maxOccurs="unbounded" minOccurs="0" name="address" type="cit:CI_Address_PropertyType">
+                  # ^ this applies to both physical and electronic addresses
                   aAddressData = Address.unpack(xContact, hResponseObj)
                   hContact[:addresses] = aAddressData[0]
                   hContact[:eMailList] = aAddressData[1]
 
-                  # :onlineResources
+                  # :onlineResources (optional)
+                  # <element maxOccurs="unbounded" minOccurs="0" name="onlineResource"
+                  # type="cit:CI_OnlineResource_PropertyType">
                   xOnlineResources = xContact.xpath(@@onlineResourceXPath)
                   unless xOnlineResources.empty?
                      hContact[:onlineResources] = xOnlineResources.map { |r| OnlineResource.unpack(r, hResponseObj) }
                   end
+
+                  # contactId: nil,
+                  # isOrganization: false,
+                  # name: nil,
+                  # externalIdentifier: [],
+                  # positionName: nil,
+                  # memberOfOrgs: [],
+                  # logos: [],
+                  # phones: [],
+                  # addresses: [],
+                  # eMailList: [],
+                  # onlineResources: [],
+                  # hoursOfService: [],
+                  # contactInstructions: nil,
+                  # contactType: nil
 
                   # memberOfOrgs & logos aren't used in the writer
                   hContact

--- a/lib/adiwg/mdtranslator/readers/iso19115_3/modules/module_maintenance.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_3/modules/module_maintenance.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+require 'adiwg/mdtranslator/internal/internal_metadata_obj'
+
+module ADIWG
+   module Mdtranslator
+      module Readers
+         module Iso191153
+            module Maintenance
+               @@maintenanceInfoXPath = 'mmi:MD_MaintenanceInformation'
+               @@frequencyXPath = 'mmi:maintenanceAndUpdateFrequency//mmi:MD_MaintenanceFrequencyCode'
+               def self.unpack(xMaintenance, _hResponseObj)
+                  intMetadataClass = InternalMetadata.new
+                  hMaintenance = intMetadataClass.newMaintenance
+
+                  xMaintenanceInfo = xMaintenance.xpath(@@maintenanceInfoXPath)[0]
+                  return nil if xMaintenanceInfo.nil?
+
+                  # only thing dcatus needs
+                  # :frequency (optional)
+                  # <element minOccurs="0" name="maintenanceAndUpdateFrequency"
+                  # type="mmi:MD_MaintenanceFrequencyCode_PropertyType">
+                  xFrequency = xMaintenanceInfo.xpath(@@frequencyXPath)[0]
+                  hMaintenance[:frequency] = xFrequency.nil? ? nil : xFrequency.attr('codeListValue')
+
+                  # TODO: as needed
+                  #    dates: [],
+                  #    scopes: [],
+                  #    notes: [],
+                  #    contacts: []
+
+                  hMaintenance
+               end
+            end
+         end
+      end
+   end
+end

--- a/lib/adiwg/mdtranslator/readers/iso19115_3/modules/module_metadata_info.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_3/modules/module_metadata_info.rb
@@ -6,6 +6,7 @@ require_relative 'module_identification'
 require_relative 'module_citation'
 require_relative 'module_locale'
 require_relative 'module_responsibility'
+require_relative 'module_maintenance'
 
 module ADIWG
    module Mdtranslator
@@ -17,11 +18,13 @@ module ADIWG
                @@defaultLocaleXPath = 'mdb:defaultLocale'
                @@otherLocaleXPath = 'mdb:otherLocale'
                @@contactXPath = 'mdb:contact'
+               @@maintenanceXPath = 'mdb:metadataMaintenance'
                def self.unpack(xMetadata, hResponseObj)
                   intMetadataClass = InternalMetadata.new
                   hMetadataInfo = intMetadataClass.newMetadataInfo
 
                   # :metadataIdentifier (optional)
+                  # <element minOccurs="0" name="metadataIdentifier" type="mcc:MD_Identifier_PropertyType"/>
                   xMetadataInfo = xMetadata.xpath(@@mdIdentifier)[0]
                   unless xMetadataInfo.nil?
                      hMetadataInfo[:metadataIdentifier] = Identification.unpack(xMetadataInfo, hResponseObj)[0]
@@ -54,10 +57,16 @@ module ADIWG
 
                   hMetadataInfo[:metadataContacts] = xContacts.map { |c| Responsibility.unpack(c, hResponseObj) }
 
+                  # :metadataMaintenance (optional) {}
+                  # <element minOccurs="0" name="metadataMaintenance"
+                  # type="mcc:Abstract_MaintenanceInformation_PropertyType"/>
+                  xMaintenance = xMetadata.xpath(@@maintenanceXPath)[0]
+                  hMetadataInfo[:metadataMaintenance] =
+                     xMaintenance.nil? ? nil : Maintenance.unpack(xMaintenance, hResponseObj)
+
                   # :metadataDates TODO
                   # :metadataLinkages TODO
                   # :metadataConstraints TODO
-                  # :metadataMaintenance TODO
                   # :alternateMetadataReferences TODO
                   # :metadataStatus TODO
                   # :extensions TODO

--- a/lib/adiwg/mdtranslator/readers/iso19115_3/modules/module_resource_info.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_3/modules/module_resource_info.rb
@@ -6,6 +6,7 @@ require_relative 'module_constraint'
 require_relative 'module_citation'
 require_relative 'module_keyword'
 require_relative 'module_extent'
+require_relative 'module_responsibility'
 
 module ADIWG
    module Mdtranslator
@@ -13,36 +14,67 @@ module ADIWG
          module Iso191153
             module ResourceInformation
                # TODO: reuse idInfo//md_Info paths instead of repeating.
-               @@constraintsXPath = 'mdb:identificationInfo//mri:MD_DataIdentification//mri:resourceConstraints'
-               @@mdIdentifierCitationXPath = 'mdb:identificationInfo//mri:MD_DataIdentification//mri:citation'
-               @@abstractXPath = 'mdb:identificationInfo//mri:MD_DataIdentification//mri:abstract//gco:CharacterString'
-               @@keywordsXPath = 'mdb:identificationInfo//mri:MD_DataIdentification//mri:descriptiveKeywords'
-               @@extentsXPath = 'mdb:identificationInfo//mri:MD_DataIdentification//mri:extent'
-               def self.unpack(xMetadata, hResponseObj)
+               @@constraintsXPath = 'mri:resourceConstraints'
+               @@mdIdentifierCitationXPath = 'mri:citation'
+               @@abstractXPath = 'mri:abstract//gco:CharacterString'
+               @@keywordsXPath = 'mri:descriptiveKeywords'
+               @@extentsXPath = 'mri:extent'
+               @@pocXPath = 'mri:pointOfContact'
+               def self.unpack(xDataIdentification, hResponseObj)
                   intMetadataClass = InternalMetadata.new
                   hResourceInfo = intMetadataClass.newResourceInfo
 
                   # just doing constraints to satisfy dcatus
-                  # :constraints
-                  xMdConstraints = xMetadata.xpath(@@constraintsXPath)
+                  # :constraints (optional)
+                  # <element maxOccurs="unbounded" minOccurs="0" name="resourceConstraints"
+                  # type="mcc:Abstract_Constraints_PropertyType"/>
+                  xMdConstraints = xDataIdentification.xpath(@@constraintsXPath)
                   aMdConstraints = xMdConstraints.map { |c| Constraint.unpack(c, hResponseObj) }.flatten
-                  hResourceInfo[:constraints] = aMdConstraints
+                  hResourceInfo[:constraints] = xMdConstraints.empty? ? nil : aMdConstraints
 
-                  # :citation
-                  xCitation = xMetadata.xpath(@@mdIdentifierCitationXPath)
+                  # :citation (required)
+                  # <element name="citation" type="mcc:Abstract_Citation_PropertyType">
+                  xCitation = xDataIdentification.xpath(@@mdIdentifierCitationXPath)[0]
+                  if xCitation.nil?
+                     msg = 'WARNING: ISO19115-3 reader: element \'cit:number\' '\
+                     'is missing in cit:phone'
+                     hResponseObj[:readerExecutionMessages] << msg
+                     hResponseObj[:readerExecutionPass] = false
+                     return hResourceInfo
+                  end
                   hResourceInfo[:citation] = Citation.unpack(xCitation, hResponseObj)
 
-                  # :abstract
-                  xAbstract = xMetadata.xpath(@@abstractXPath)[0]
+                  # :abstract (required)
+                  # <element name="abstract" type="gco:CharacterString_PropertyType">
+                  xAbstract = xDataIdentification.xpath(@@abstractXPath)[0]
+                  if xAbstract.nil?
+                     msg = 'WARNING: ISO19115-3 reader: element \'mri:abstract & gco:CharacterString\' '\
+                     'is missing in mri:MD_DataIdentification'
+                     hResponseObj[:readerExecutionMessages] << msg
+                     hResponseObj[:readerExecutionPass] = false
+                     return hResourceInfo
+                  end
+
                   hResourceInfo[:abstract] = xAbstract.nil? ? nil : xAbstract.text
 
-                  # :keywords
-                  xKeywords = xMetadata.xpath(@@keywordsXPath)
+                  # :keywords (optional)
+                  # <element maxOccurs="unbounded" minOccurs="0" name="descriptiveKeywords"
+                  # type="mri:MD_Keywords_PropertyType"/>
+                  xKeywords = xDataIdentification.xpath(@@keywordsXPath)
                   hResourceInfo[:keywords] = xKeywords.map { |k| Keyword.unpack(k, hResponseObj) }
 
-                  # :extents
-                  xExtents = xMetadata.xpath(@@extentsXPath)
+                  # :extents (optional)
+                  # <element maxOccurs="unbounded" minOccurs="0" name="extent" type="mcc:Abstract_Extent_PropertyType">
+                  xExtents = xDataIdentification.xpath(@@extentsXPath)
                   hResourceInfo[:extents] = xExtents.map { |e| Extent.unpack(e, hResponseObj) }
+
+                  # :pointOfContacts (optional)
+                  # <element maxOccurs="unbounded" minOccurs="0" name="pointOfContact"
+                  # type="mcc:Abstract_Responsibility_PropertyType">
+                  xPointOfContacts = xDataIdentification.xpath(@@pocXPath)
+                  hResourceInfo[:pointOfContacts] = xPointOfContacts.map do |poc|
+                     Responsibility.unpack(poc, hResponseObj)
+                  end
 
                   hResourceInfo
                end

--- a/lib/adiwg/mdtranslator/readers/iso19115_3/modules/module_responsibility.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_3/modules/module_responsibility.rb
@@ -34,6 +34,7 @@ module ADIWG
                   end
 
                   # cit: role (required)
+                  # <element name="role" type="cit:CI_RoleCode_PropertyType">
                   xRoleCode = xRespblty.xpath(@@roleCodeXpath)[0]
                   if xRoleCode.nil?
                      msg = 'ERROR: ISO19115-3 reader: element \'cit:role\' is missing in cit:CI_Responsibility'
@@ -46,10 +47,13 @@ module ADIWG
                   hRespblty[:roleName] = xRoleCode.attr(codeListValue)
 
                   # :roleExtents (optional)
+                  # <element maxOccurs="unbounded" minOccurs="0" name="extent"
+                  # type="mcc:Abstract_Extent_PropertyType">
                   xExtents = xRespblty.xpath(@@extentXPath)
                   hRespblty[:roleExtents] = xExtents.map { |e| Extent.unpack(e, hResponseObj) }
 
                   # :parties (required)
+                  # <element maxOccurs="unbounded" name="party" type="cit:AbstractCI_Party_PropertyType"/>
                   xParties = xRespblty.xpath(@@partyXPath)
                   if xParties.empty?
                      msg = 'ERROR: ISO19115-3 reader: element \'cit:party\' is missing in cit:CI_Responsibility'

--- a/test/readers/iso19115_3/tc_iso19115_3_contact.rb
+++ b/test/readers/iso19115_3/tc_iso19115_3_contact.rb
@@ -29,7 +29,8 @@ class TestReaderIso191153Contact < TestReaderIso191153Parent
       assert_equal(1, hDictionary[:addresses].size)
       assert_equal(['email@address.com', 'another@address.com'], hDictionary[:eMailList])
 
-      assert_equal('Monday - Friday 8:00am - 5:00pm', hDictionary[:hoursOfService])
+      assert hDictionary[:hoursOfService].instance_of? Array
+      assert_equal(['Monday - Friday 8:00am - 5:00pm', 'Sunday 10:00am - 2:00pm'], hDictionary[:hoursOfService])
       assert_equal('contact by phone', hDictionary[:contactInstructions])
       assert_equal('federal', hDictionary[:contactType])
 

--- a/test/readers/iso19115_3/tc_iso19115_3_maintenance.rb
+++ b/test/readers/iso19115_3/tc_iso19115_3_maintenance.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# MdTranslator - minitest of
+# readers / iso19115-3 / module_maintenance
+
+require 'adiwg/mdtranslator/readers/iso19115_3/modules/module_maintenance'
+require_relative 'iso19115_3_test_parent'
+
+class TestReaderIso191153Maintenance < TestReaderIso191153Parent
+   @@xDoc = TestReaderIso191153Parent.get_xml('iso19115-3.xml')
+   @@nameSpace = ADIWG::Mdtranslator::Readers::Iso191153::Maintenance
+
+   def test_maintenance_complete
+      TestReaderIso191153Parent.set_xdoc(@@xDoc)
+
+      xIn = @@xDoc.xpath('.//mdb:metadataMaintenance')[0]
+      hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
+      hDictionary = @@nameSpace.unpack(xIn, hResponse)
+
+      refute_empty hDictionary
+      assert hDictionary.instance_of? Hash
+      assert_equal('bimonthly', hDictionary[:frequency])
+   end
+end

--- a/test/readers/iso19115_3/testData/iso19115-3.xml
+++ b/test/readers/iso19115_3/testData/iso19115-3.xml
@@ -886,6 +886,9 @@
                      <cit:hoursOfService>
                         <gco:CharacterString>Monday - Friday 8:00am - 5:00pm</gco:CharacterString>
                      </cit:hoursOfService>
+                     <cit:hoursOfService>
+                        <gco:CharacterString>Sunday 10:00am - 2:00pm</gco:CharacterString>
+                     </cit:hoursOfService>
                      <cit:phone>
                         <cit:CI_Telephone>
                            <cit:number>
@@ -1053,11 +1056,27 @@
                <cit:title>
                   <gco:CharacterString>Spatial data: A large-scale database of modeled contemporary and future water temperature data for 10,774 Michigan, Minnesota and Wisconsin Lakes</gco:CharacterString>
                </cit:title>
+               <cit:identifier>
+                  <mcc:MD_Identifier>
+                     <mcc:authority/>
+                     <mcc:code>
+                        <gco:CharacterString>10293u0wjdoaksd98h</gco:CharacterString>
+                     </mcc:code>
+                     <mcc:codeSpace>
+                        <gco:CharacterString>gov.sciencetest.catalog</gco:CharacterString>
+                     </mcc:codeSpace>
+                     <mcc:version/>
+                     <mcc:description>
+                        <gco:CharacterString>USGS ScienceTest Test Center</gco:CharacterString>
+                     </mcc:description>
+                  </mcc:MD_Identifier>
+               </cit:identifier>
                <cit:onlineResource>
                   <cit:CI_OnlineResource>
                      <cit:linkage>
                         <gco:CharacterString>http://dx.doi.org/10.5066/F7DV1H10</gco:CharacterString>
                      </cit:linkage>
+                     <cit:function codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_OnlineResource" codeListValue="landingPage" codeSpace="998"/>
                   </cit:CI_OnlineResource>
                </cit:onlineResource>
                <cit:date>
@@ -2001,6 +2020,31 @@
             </mri:MD_AssociatedResource>
          </mri:associatedResource>
 
+         <mri:associatedResource>
+            <mri:MD_AssociatedResource>
+               <mri:name>
+                  <cit:CI_Citation>
+                     <cit:title>
+                        <gco:CharacterString>Associated Resource Citation Title 10293ua</gco:CharacterString>
+                     </cit:title>
+                     <cit:onlineResource>
+                        <cit:CI_OnlineResource>
+                           <cit:linkage>
+                              <gco:CharacterString>http://as0d1028h3.associated.org/10/F7DV1H10</gco:CharacterString>
+                           </cit:linkage>
+                        </cit:CI_OnlineResource>
+                     </cit:onlineResource>
+                  </cit:CI_Citation>
+               </mri:name>
+               <mri:associationType>
+                  <mri:DS_AssociationTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_OnlineResource" codeListValue="collectiveTitle" codeSpace="adiwg002"/>
+               </mri:associationType>
+               <mri:initiativeType>
+                  <mri:DS_InitiativeTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_OnlineResource" codeListValue="sorn" codeSpace="adiwg999"/>
+               </mri:initiativeType>
+            </mri:MD_AssociatedResource>
+         </mri:associatedResource>
+         
          <mri:additionalDocumentation>
             <cit:CI_Citation>
                <cit:title>
@@ -2030,6 +2074,172 @@
             </cit:CI_Citation>
          </mri:additionalDocumentation>
 
+         <mri:pointOfContact>
+            <cit:CI_Responsibility>
+               <cit:role>
+                  <cit:CI_RoleCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_RoleCode" codeListValue="author" codeSpace="011"/>
+               </cit:role>
+               <cit:party>
+                  <cit:CI_Individual>
+                     <cit:name>
+                        <gco:CharacterString>Robert G Test</gco:CharacterString>
+                     </cit:name>
+                     <cit:positionName>
+                        <gco:CharacterString>Metadata Manager</gco:CharacterString>
+                     </cit:positionName>
+                     <cit:contactInfo>
+                        <cit:CI_Contact>
+                           <cit:contactType>
+                              <gco:CharacterString>federal</gco:CharacterString>
+                           </cit:contactType>
+                           <cit:contactInstructions>
+                              <gco:CharacterString>contact by phone</gco:CharacterString>
+                           </cit:contactInstructions>
+                           <cit:hoursOfService>
+                              <gco:CharacterString>Monday - Friday 8:00am - 5:00pm</gco:CharacterString>
+                           </cit:hoursOfService>
+                           <cit:hoursOfService>
+                              <gco:CharacterString>Sunday 10:00am - 2:00pm</gco:CharacterString>
+                           </cit:hoursOfService>
+                           <cit:phone>
+                              <cit:CI_Telephone>
+                                 <cit:number>
+                                    <gco:CharacterString>+61 3 6232 5222</gco:CharacterString>
+                                 </cit:number>
+                                 <cit:numberType>
+                                    <cit:CI_TelephoneTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#CI_RoleCode"
+                                                               codeListValue="voice"/>
+                                 </cit:numberType>
+                              </cit:CI_Telephone>
+                           </cit:phone>
+                           <cit:address>
+                              <cit:CI_Address>
+                                 <cit:deliveryPoint>
+                                    <gco:CharacterString>123 ABC Road</gco:CharacterString>
+                                 </cit:deliveryPoint>
+                                 <cit:deliveryPoint>
+                                    <gco:CharacterString>456 DEF St</gco:CharacterString>
+                                 </cit:deliveryPoint>
+                                 <cit:city>
+                                    <gco:CharacterString>Sacramento</gco:CharacterString>
+                                 </cit:city>
+                                 <cit:administrativeArea>
+                                    <gco:CharacterString>California</gco:CharacterString>
+                                 </cit:administrativeArea>
+                                 <cit:postalCode>
+                                    <gco:CharacterString>90210</gco:CharacterString>
+                                 </cit:postalCode>
+                                 <cit:country>
+                                    <gco:CharacterString>United States</gco:CharacterString>
+                                 </cit:country>
+                                 <cit:electronicMailAddress>
+                                    <gco:CharacterString>email@address.com</gco:CharacterString>
+                                 </cit:electronicMailAddress>
+                                 <cit:electronicMailAddress>
+                                    <gco:CharacterString>another@address.com</gco:CharacterString>
+                                 </cit:electronicMailAddress>
+                              </cit:CI_Address>
+                           </cit:address>
+                           <cit:onlineResource>
+                              <cit:CI_OnlineResource>
+                                 <cit:linkage>
+                                    <gco:CharacterString>http://onlineresourceexample.com</gco:CharacterString>
+                                 </cit:linkage>
+                                 <cit:protocol>
+                                    <gco:CharacterString>http</gco:CharacterString>
+                                 </cit:protocol>
+                                 <cit:applicationProfile>
+                                    <gco:CharacterString>application-profile-example</gco:CharacterString>
+                                 </cit:applicationProfile>
+                                 <cit:name>
+                                    <gco:CharacterString>online resource name</gco:CharacterString>
+                                 </cit:name>
+                                 <cit:description>
+                                    <gco:CharacterString>online resource description</gco:CharacterString>
+                                 </cit:description>
+                                 <cit:function codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_OnlineResource" codeListValue="online information about the resource" codeSpace="999"/>
+                                 <cit:protocolRequest>
+                                    <gco:CharacterString>protocol request example</gco:CharacterString>
+                                 </cit:protocolRequest>
+                              </cit:CI_OnlineResource>
+                           </cit:onlineResource>
+                        </cit:CI_Contact>
+                     </cit:contactInfo>
+                     <cit:partyIdentifier>
+                        <mcc:MD_Identifier>
+                           <mcc:authority/>
+                           <mcc:code>
+                              <gco:CharacterString>party 123456</gco:CharacterString>
+                           </mcc:code>
+                           <mcc:codeSpace>
+                              <gco:CharacterString>F506</gco:CharacterString>
+                           </mcc:codeSpace>
+                           <mcc:version>
+                              <gco:CharacterString>1.0</gco:CharacterString>
+                           </mcc:version>
+                        </mcc:MD_Identifier>
+                     </cit:partyIdentifier>
+                  </cit:CI_Individual>
+               </cit:party>
+               <cit:party>
+                  <cit:CI_Organisation>
+                     <cit:name>
+                        <gco:CharacterString>Commonwealth of Australia (Geoscience Australia)</gco:CharacterString>
+                     </cit:name>
+                     <cit:contactInfo>
+                        <cit:CI_Contact>
+                           <cit:phone>
+                              <cit:CI_Telephone>
+                                 <cit:number>
+                                    <gco:CharacterString>02 6249 9966</gco:CharacterString>
+                                 </cit:number>
+                                 <cit:numberType>
+                                 <cit:CI_TelephoneTypeCode codeList="codeListLocation#CI_TelephoneTypeCode" codeListValue="voice"/>
+                                 </cit:numberType>
+                              </cit:CI_Telephone>
+                           </cit:phone>
+                           <cit:phone>
+                              <cit:CI_Telephone>
+                                 <cit:number>
+                                    <gco:CharacterString>02 6249 9960</gco:CharacterString>
+                                 </cit:number>
+                                 <cit:numberType>
+                                 <cit:CI_TelephoneTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_TelephoneTypeCode" codeListValue="fax"/>
+                                 </cit:numberType>
+                              </cit:CI_Telephone>
+                           </cit:phone>
+                           <cit:address>
+                              <cit:CI_Address>
+                                 <cit:deliveryPoint>
+                                    <gco:CharacterString>Cnr Jerrabomberra Ave and Hindmarsh Dr</gco:CharacterString>
+                                 </cit:deliveryPoint>
+                                 <cit:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 378</gco:CharacterString>
+                                 </cit:deliveryPoint>
+                                 <cit:city>
+                                    <gco:CharacterString>Canberra</gco:CharacterString>
+                                 </cit:city>
+                                 <cit:administrativeArea>
+                                    <gco:CharacterString>ACT</gco:CharacterString>
+                                 </cit:administrativeArea>
+                                 <cit:postalCode>
+                                    <gco:CharacterString>2601</gco:CharacterString>
+                                 </cit:postalCode>
+                                 <cit:country>
+                                    <gco:CharacterString>Australia</gco:CharacterString>
+                                 </cit:country>
+                                 <cit:electronicMailAddress>
+                                    <gco:CharacterString>clientservices@ga.gov.au</gco:CharacterString>
+                                 </cit:electronicMailAddress>
+                              </cit:CI_Address>
+                           </cit:address>
+                        </cit:CI_Contact>
+                     </cit:contactInfo>
+                  </cit:CI_Organisation>
+               </cit:party>
+            </cit:CI_Responsibility>
+         </mri:pointOfContact>
+
       </mri:MD_DataIdentification>
    </mdb:identificationInfo>
    <mdb:contentInfo>
@@ -2047,6 +2257,9 @@
                      <cit:linkage>
                         <gco:CharacterString>http://test.something.org/10/F7DV1H10</gco:CharacterString>
                      </cit:linkage>
+                     <cit:protocol>
+                        <gco:CharacterString>https</gco:CharacterString>
+                     </cit:protocol>
                   </cit:CI_OnlineResource>
                </cit:onlineResource>
             </cit:CI_Citation>
@@ -2072,4 +2285,133 @@
          </mrc:featureCatalogueCitation>
       </mrc:MD_FeatureCatalogueDescription>
    </mdb:contentInfo>
+   <mdb:contentInfo>
+      <mrc:MD_FeatureCatalogueDescription>
+         <mrc:includedWithDataset>
+            <gco:Boolean>true</gco:Boolean>
+         </mrc:includedWithDataset>
+         <mrc:featureCatalogueCitation>
+            <cit:CI_Citation>
+               <cit:title>
+                  <gco:CharacterString>Test Agency Feat. Catalog abc.1234</gco:CharacterString>
+               </cit:title>
+               <cit:CI_OnlineResource>
+                  <cit:linkage>
+                     <gco:CharacterString>http://example.something.org/98/data.json</gco:CharacterString>
+                  </cit:linkage>
+               </cit:CI_OnlineResource>
+            </cit:CI_Citation>
+         </mrc:featureCatalogueCitation>
+      </mrc:MD_FeatureCatalogueDescription>
+   </mdb:contentInfo>
+
+   <mdb:metadataMaintenance>
+    <mmi:MD_MaintenanceInformation>
+      <mmi:maintenanceAndUpdateFrequency>
+        <mmi:MD_MaintenanceFrequencyCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_MaintenanceFrequencyCode" codeListValue="bimonthly" codeSpace="userCode"/>
+      </mmi:maintenanceAndUpdateFrequency>
+      <mmi:maintenanceDate>
+        <cit:CI_Date>
+          <cit:date>
+            <gco:Date>2018-05-25</gco:Date>
+          </cit:date>
+          <cit:dateType>
+            <cit:CI_DateTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_DateTypeCode" codeListValue="lastUpdate" codeSpace="005"/>
+          </cit:dateType>
+        </cit:CI_Date>
+      </mmi:maintenanceDate>
+      <mmi:maintenanceDate>
+        <cit:CI_Date>
+          <cit:date>
+            <gco:Date>2019-04</gco:Date>
+          </cit:date>
+          <cit:dateType>
+            <cit:CI_DateTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_DateTypeCode" codeListValue="nextUpdate" codeSpace="007"/>
+          </cit:dateType>
+        </cit:CI_Date>
+      </mmi:maintenanceDate>
+      <mmi:maintenanceScope>
+        <mcc:MD_Scope>
+          <mcc:level>
+            <mcc:MD_ScopeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_ScopeCode" codeListValue="scope code" codeSpace="userCode"/>
+          </mcc:level>
+          <mcc:extent/>
+          <mcc:levelDescription/>
+        </mcc:MD_Scope>
+      </mmi:maintenanceScope>
+      <mmi:maintenanceScope>
+        <mcc:MD_Scope>
+          <mcc:level>
+            <mcc:MD_ScopeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_ScopeCode" codeListValue="scope code" codeSpace="userCode"/>
+          </mcc:level>
+          <mcc:extent/>
+          <mcc:levelDescription/>
+        </mcc:MD_Scope>
+      </mmi:maintenanceScope>
+      <mmi:maintenanceNote>
+        <gco:CharacterString>note one</gco:CharacterString>
+      </mmi:maintenanceNote>
+      <mmi:maintenanceNote>
+        <gco:CharacterString>note two</gco:CharacterString>
+      </mmi:maintenanceNote>
+      <mmi:contact>
+        <cit:CI_Responsibility>
+          <cit:role>
+            <cit:CI_RoleCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_RoleCode" codeListValue="custodian" codeSpace="002"/>
+          </cit:role>
+          <cit:extent/>
+          <cit:party>
+            <cit:CI_Individual>
+              <cit:name>
+                <gco:CharacterString>person name three</gco:CharacterString>
+              </cit:name>
+              <cit:contactInfo/>
+              <cit:partyIdentifier>
+                <mcc:MD_Identifier>
+                  <mcc:authority/>
+                  <mcc:code>
+                    <gco:CharacterString>CID003</gco:CharacterString>
+                  </mcc:code>
+                  <mcc:codeSpace/>
+                  <mcc:version/>
+                  <mcc:description/>
+                </mcc:MD_Identifier>
+              </cit:partyIdentifier>
+              <cit:positionName/>
+            </cit:CI_Individual>
+          </cit:party>
+        </cit:CI_Responsibility>
+      </mmi:contact>
+      <mmi:contact>
+        <cit:CI_Responsibility>
+          <cit:role>
+            <cit:CI_RoleCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_RoleCode" codeListValue="rightHolder" codeSpace="userCode"/>
+          </cit:role>
+          <cit:extent/>
+          <cit:party>
+            <cit:CI_Organisation>
+              <cit:name>
+                <gco:CharacterString>organization name four</gco:CharacterString>
+              </cit:name>
+              <cit:contactInfo/>
+              <cit:partyIdentifier>
+                <mcc:MD_Identifier>
+                  <mcc:authority/>
+                  <mcc:code>
+                    <gco:CharacterString>CID004</gco:CharacterString>
+                  </mcc:code>
+                  <mcc:codeSpace/>
+                  <mcc:version/>
+                  <mcc:description/>
+                </mcc:MD_Identifier>
+              </cit:partyIdentifier>
+              <cit:logo/>
+              <cit:individual/>
+            </cit:CI_Organisation>
+          </cit:party>
+        </cit:CI_Responsibility>
+      </mmi:contact>
+    </mmi:MD_MaintenanceInformation>
+  </mdb:metadataMaintenance>
+
 </mdb:MD_Metadata>

--- a/test/translator/tc_iso19115_3_to_dcatus.rb
+++ b/test/translator/tc_iso19115_3_to_dcatus.rb
@@ -103,8 +103,7 @@ class TestIso191153DcatusTranslation < Minitest::Test
    #    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Publisher
    # end
 
-   # TODO: see comment above
-   # contactPoint
+   # TODO: skipping contact point which relies on contact info
 
    def test_access_level_translate
       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::AccessLevel
@@ -113,8 +112,12 @@ class TestIso191153DcatusTranslation < Minitest::Test
       assert_equal('non-public', res)
    end
 
-   # TODO: the code looks a tad weird. gonna meet with johnathan.
-   # identifier
+   def test_identifier_translate
+      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Identifier
+      res = dcatusNS.build(@@intMetadata)
+
+      assert_equal('http://dx.doi.org/10.5066/F7DV1H10', res)
+   end
 
    def test_distribution_translate
       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Distribution
@@ -209,9 +212,49 @@ class TestIso191153DcatusTranslation < Minitest::Test
       res = dcatusNS.build(@@intMetadata)
 
       expected = 'http://resource.associated.org/10/F7DV1H10,' \
+      'http://as0d1028h3.associated.org/10/F7DV1H10,'\
       'http://dx.doi.org/10.5066/F7DV1H10,http://additional.doc/10/F7DV1H10,' \
       'http://additional.doc/56/data.json'
 
       assert_equal(expected, res)
    end
+
+   def test_landing_page_translate
+      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::LandingPage
+      res = dcatusNS.build(@@intMetadata)
+
+      assert_equal('http://dx.doi.org/10.5066/F7DV1H10', res)
+   end
+
+   def test_system_of_records_translate
+      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::SystemOfRecords
+      res = dcatusNS.build(@@intMetadata)
+
+      assert_equal('http://as0d1028h3.associated.org/10/F7DV1H10', res)
+   end
+
+   def test_describe_by_type_translate
+      # describebytype returns the protocol of the first non-empty url str
+      # that doesnt end with '.html' which can produce nils. odd.
+      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::DescribedByType
+      res = dcatusNS.build(@@intMetadata)
+
+      assert_equal('https', res)
+   end
+
+   def test_accrual_periodicity_translate
+      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::AccrualPeriodicity
+      res = dcatusNS.build(@@intMetadata)
+
+      assert_equal('R/P2M or R/P0.5M', res)
+   end
+
+   def test_primaryit_investment_uii
+      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::PrimaryITInvestmentUII
+      res = dcatusNS.build(@@intMetadata)
+
+      assert_equal('57d97341e4b090824ffb0e6f', res)
+   end
+
+   # TODO: program code (need to handle how contacts/parties are stored)
 end

--- a/test/translator/testData/iso19115-3.xml
+++ b/test/translator/testData/iso19115-3.xml
@@ -886,6 +886,9 @@
                      <cit:hoursOfService>
                         <gco:CharacterString>Monday - Friday 8:00am - 5:00pm</gco:CharacterString>
                      </cit:hoursOfService>
+                     <cit:hoursOfService>
+                        <gco:CharacterString>Sunday 10:00am - 2:00pm</gco:CharacterString>
+                     </cit:hoursOfService>
                      <cit:phone>
                         <cit:CI_Telephone>
                            <cit:number>
@@ -1053,11 +1056,27 @@
                <cit:title>
                   <gco:CharacterString>Spatial data: A large-scale database of modeled contemporary and future water temperature data for 10,774 Michigan, Minnesota and Wisconsin Lakes</gco:CharacterString>
                </cit:title>
+               <cit:identifier>
+                  <mcc:MD_Identifier>
+                     <mcc:authority/>
+                     <mcc:code>
+                        <gco:CharacterString>10293u0wjdoaksd98h</gco:CharacterString>
+                     </mcc:code>
+                     <mcc:codeSpace>
+                        <gco:CharacterString>gov.sciencetest.catalog</gco:CharacterString>
+                     </mcc:codeSpace>
+                     <mcc:version/>
+                     <mcc:description>
+                        <gco:CharacterString>USGS ScienceTest Test Center</gco:CharacterString>
+                     </mcc:description>
+                  </mcc:MD_Identifier>
+               </cit:identifier>
                <cit:onlineResource>
                   <cit:CI_OnlineResource>
                      <cit:linkage>
                         <gco:CharacterString>http://dx.doi.org/10.5066/F7DV1H10</gco:CharacterString>
                      </cit:linkage>
+                     <cit:function codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_OnlineResource" codeListValue="landingPage" codeSpace="998"/>
                   </cit:CI_OnlineResource>
                </cit:onlineResource>
                <cit:date>
@@ -2001,6 +2020,31 @@
             </mri:MD_AssociatedResource>
          </mri:associatedResource>
 
+         <mri:associatedResource>
+            <mri:MD_AssociatedResource>
+               <mri:name>
+                  <cit:CI_Citation>
+                     <cit:title>
+                        <gco:CharacterString>Associated Resource Citation Title 10293ua</gco:CharacterString>
+                     </cit:title>
+                     <cit:onlineResource>
+                        <cit:CI_OnlineResource>
+                           <cit:linkage>
+                              <gco:CharacterString>http://as0d1028h3.associated.org/10/F7DV1H10</gco:CharacterString>
+                           </cit:linkage>
+                        </cit:CI_OnlineResource>
+                     </cit:onlineResource>
+                  </cit:CI_Citation>
+               </mri:name>
+               <mri:associationType>
+                  <mri:DS_AssociationTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_OnlineResource" codeListValue="collectiveTitle" codeSpace="adiwg002"/>
+               </mri:associationType>
+               <mri:initiativeType>
+                  <mri:DS_InitiativeTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_OnlineResource" codeListValue="sorn" codeSpace="adiwg999"/>
+               </mri:initiativeType>
+            </mri:MD_AssociatedResource>
+         </mri:associatedResource>
+         
          <mri:additionalDocumentation>
             <cit:CI_Citation>
                <cit:title>
@@ -2030,6 +2074,172 @@
             </cit:CI_Citation>
          </mri:additionalDocumentation>
 
+         <mri:pointOfContact>
+            <cit:CI_Responsibility>
+               <cit:role>
+                  <cit:CI_RoleCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_RoleCode" codeListValue="author" codeSpace="011"/>
+               </cit:role>
+               <cit:party>
+                  <cit:CI_Individual>
+                     <cit:name>
+                        <gco:CharacterString>Robert G Test</gco:CharacterString>
+                     </cit:name>
+                     <cit:positionName>
+                        <gco:CharacterString>Metadata Manager</gco:CharacterString>
+                     </cit:positionName>
+                     <cit:contactInfo>
+                        <cit:CI_Contact>
+                           <cit:contactType>
+                              <gco:CharacterString>federal</gco:CharacterString>
+                           </cit:contactType>
+                           <cit:contactInstructions>
+                              <gco:CharacterString>contact by phone</gco:CharacterString>
+                           </cit:contactInstructions>
+                           <cit:hoursOfService>
+                              <gco:CharacterString>Monday - Friday 8:00am - 5:00pm</gco:CharacterString>
+                           </cit:hoursOfService>
+                           <cit:hoursOfService>
+                              <gco:CharacterString>Sunday 10:00am - 2:00pm</gco:CharacterString>
+                           </cit:hoursOfService>
+                           <cit:phone>
+                              <cit:CI_Telephone>
+                                 <cit:number>
+                                    <gco:CharacterString>+61 3 6232 5222</gco:CharacterString>
+                                 </cit:number>
+                                 <cit:numberType>
+                                    <cit:CI_TelephoneTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#CI_RoleCode"
+                                                               codeListValue="voice"/>
+                                 </cit:numberType>
+                              </cit:CI_Telephone>
+                           </cit:phone>
+                           <cit:address>
+                              <cit:CI_Address>
+                                 <cit:deliveryPoint>
+                                    <gco:CharacterString>123 ABC Road</gco:CharacterString>
+                                 </cit:deliveryPoint>
+                                 <cit:deliveryPoint>
+                                    <gco:CharacterString>456 DEF St</gco:CharacterString>
+                                 </cit:deliveryPoint>
+                                 <cit:city>
+                                    <gco:CharacterString>Sacramento</gco:CharacterString>
+                                 </cit:city>
+                                 <cit:administrativeArea>
+                                    <gco:CharacterString>California</gco:CharacterString>
+                                 </cit:administrativeArea>
+                                 <cit:postalCode>
+                                    <gco:CharacterString>90210</gco:CharacterString>
+                                 </cit:postalCode>
+                                 <cit:country>
+                                    <gco:CharacterString>United States</gco:CharacterString>
+                                 </cit:country>
+                                 <cit:electronicMailAddress>
+                                    <gco:CharacterString>email@address.com</gco:CharacterString>
+                                 </cit:electronicMailAddress>
+                                 <cit:electronicMailAddress>
+                                    <gco:CharacterString>another@address.com</gco:CharacterString>
+                                 </cit:electronicMailAddress>
+                              </cit:CI_Address>
+                           </cit:address>
+                           <cit:onlineResource>
+                              <cit:CI_OnlineResource>
+                                 <cit:linkage>
+                                    <gco:CharacterString>http://onlineresourceexample.com</gco:CharacterString>
+                                 </cit:linkage>
+                                 <cit:protocol>
+                                    <gco:CharacterString>http</gco:CharacterString>
+                                 </cit:protocol>
+                                 <cit:applicationProfile>
+                                    <gco:CharacterString>application-profile-example</gco:CharacterString>
+                                 </cit:applicationProfile>
+                                 <cit:name>
+                                    <gco:CharacterString>online resource name</gco:CharacterString>
+                                 </cit:name>
+                                 <cit:description>
+                                    <gco:CharacterString>online resource description</gco:CharacterString>
+                                 </cit:description>
+                                 <cit:function codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_OnlineResource" codeListValue="online information about the resource" codeSpace="999"/>
+                                 <cit:protocolRequest>
+                                    <gco:CharacterString>protocol request example</gco:CharacterString>
+                                 </cit:protocolRequest>
+                              </cit:CI_OnlineResource>
+                           </cit:onlineResource>
+                        </cit:CI_Contact>
+                     </cit:contactInfo>
+                     <cit:partyIdentifier>
+                        <mcc:MD_Identifier>
+                           <mcc:authority/>
+                           <mcc:code>
+                              <gco:CharacterString>party 123456</gco:CharacterString>
+                           </mcc:code>
+                           <mcc:codeSpace>
+                              <gco:CharacterString>F506</gco:CharacterString>
+                           </mcc:codeSpace>
+                           <mcc:version>
+                              <gco:CharacterString>1.0</gco:CharacterString>
+                           </mcc:version>
+                        </mcc:MD_Identifier>
+                     </cit:partyIdentifier>
+                  </cit:CI_Individual>
+               </cit:party>
+               <cit:party>
+                  <cit:CI_Organisation>
+                     <cit:name>
+                        <gco:CharacterString>Commonwealth of Australia (Geoscience Australia)</gco:CharacterString>
+                     </cit:name>
+                     <cit:contactInfo>
+                        <cit:CI_Contact>
+                           <cit:phone>
+                              <cit:CI_Telephone>
+                                 <cit:number>
+                                    <gco:CharacterString>02 6249 9966</gco:CharacterString>
+                                 </cit:number>
+                                 <cit:numberType>
+                                 <cit:CI_TelephoneTypeCode codeList="codeListLocation#CI_TelephoneTypeCode" codeListValue="voice"/>
+                                 </cit:numberType>
+                              </cit:CI_Telephone>
+                           </cit:phone>
+                           <cit:phone>
+                              <cit:CI_Telephone>
+                                 <cit:number>
+                                    <gco:CharacterString>02 6249 9960</gco:CharacterString>
+                                 </cit:number>
+                                 <cit:numberType>
+                                 <cit:CI_TelephoneTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_TelephoneTypeCode" codeListValue="fax"/>
+                                 </cit:numberType>
+                              </cit:CI_Telephone>
+                           </cit:phone>
+                           <cit:address>
+                              <cit:CI_Address>
+                                 <cit:deliveryPoint>
+                                    <gco:CharacterString>Cnr Jerrabomberra Ave and Hindmarsh Dr</gco:CharacterString>
+                                 </cit:deliveryPoint>
+                                 <cit:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 378</gco:CharacterString>
+                                 </cit:deliveryPoint>
+                                 <cit:city>
+                                    <gco:CharacterString>Canberra</gco:CharacterString>
+                                 </cit:city>
+                                 <cit:administrativeArea>
+                                    <gco:CharacterString>ACT</gco:CharacterString>
+                                 </cit:administrativeArea>
+                                 <cit:postalCode>
+                                    <gco:CharacterString>2601</gco:CharacterString>
+                                 </cit:postalCode>
+                                 <cit:country>
+                                    <gco:CharacterString>Australia</gco:CharacterString>
+                                 </cit:country>
+                                 <cit:electronicMailAddress>
+                                    <gco:CharacterString>clientservices@ga.gov.au</gco:CharacterString>
+                                 </cit:electronicMailAddress>
+                              </cit:CI_Address>
+                           </cit:address>
+                        </cit:CI_Contact>
+                     </cit:contactInfo>
+                  </cit:CI_Organisation>
+               </cit:party>
+            </cit:CI_Responsibility>
+         </mri:pointOfContact>
+
       </mri:MD_DataIdentification>
    </mdb:identificationInfo>
    <mdb:contentInfo>
@@ -2047,6 +2257,9 @@
                      <cit:linkage>
                         <gco:CharacterString>http://test.something.org/10/F7DV1H10</gco:CharacterString>
                      </cit:linkage>
+                     <cit:protocol>
+                        <gco:CharacterString>https</gco:CharacterString>
+                     </cit:protocol>
                   </cit:CI_OnlineResource>
                </cit:onlineResource>
             </cit:CI_Citation>
@@ -2072,4 +2285,133 @@
          </mrc:featureCatalogueCitation>
       </mrc:MD_FeatureCatalogueDescription>
    </mdb:contentInfo>
+   <mdb:contentInfo>
+      <mrc:MD_FeatureCatalogueDescription>
+         <mrc:includedWithDataset>
+            <gco:Boolean>true</gco:Boolean>
+         </mrc:includedWithDataset>
+         <mrc:featureCatalogueCitation>
+            <cit:CI_Citation>
+               <cit:title>
+                  <gco:CharacterString>Test Agency Feat. Catalog abc.1234</gco:CharacterString>
+               </cit:title>
+               <cit:CI_OnlineResource>
+                  <cit:linkage>
+                     <gco:CharacterString>http://example.something.org/98/data.json</gco:CharacterString>
+                  </cit:linkage>
+               </cit:CI_OnlineResource>
+            </cit:CI_Citation>
+         </mrc:featureCatalogueCitation>
+      </mrc:MD_FeatureCatalogueDescription>
+   </mdb:contentInfo>
+
+   <mdb:metadataMaintenance>
+    <mmi:MD_MaintenanceInformation>
+      <mmi:maintenanceAndUpdateFrequency>
+        <mmi:MD_MaintenanceFrequencyCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_MaintenanceFrequencyCode" codeListValue="bimonthly" codeSpace="userCode"/>
+      </mmi:maintenanceAndUpdateFrequency>
+      <mmi:maintenanceDate>
+        <cit:CI_Date>
+          <cit:date>
+            <gco:Date>2018-05-25</gco:Date>
+          </cit:date>
+          <cit:dateType>
+            <cit:CI_DateTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_DateTypeCode" codeListValue="lastUpdate" codeSpace="005"/>
+          </cit:dateType>
+        </cit:CI_Date>
+      </mmi:maintenanceDate>
+      <mmi:maintenanceDate>
+        <cit:CI_Date>
+          <cit:date>
+            <gco:Date>2019-04</gco:Date>
+          </cit:date>
+          <cit:dateType>
+            <cit:CI_DateTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_DateTypeCode" codeListValue="nextUpdate" codeSpace="007"/>
+          </cit:dateType>
+        </cit:CI_Date>
+      </mmi:maintenanceDate>
+      <mmi:maintenanceScope>
+        <mcc:MD_Scope>
+          <mcc:level>
+            <mcc:MD_ScopeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_ScopeCode" codeListValue="scope code" codeSpace="userCode"/>
+          </mcc:level>
+          <mcc:extent/>
+          <mcc:levelDescription/>
+        </mcc:MD_Scope>
+      </mmi:maintenanceScope>
+      <mmi:maintenanceScope>
+        <mcc:MD_Scope>
+          <mcc:level>
+            <mcc:MD_ScopeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_ScopeCode" codeListValue="scope code" codeSpace="userCode"/>
+          </mcc:level>
+          <mcc:extent/>
+          <mcc:levelDescription/>
+        </mcc:MD_Scope>
+      </mmi:maintenanceScope>
+      <mmi:maintenanceNote>
+        <gco:CharacterString>note one</gco:CharacterString>
+      </mmi:maintenanceNote>
+      <mmi:maintenanceNote>
+        <gco:CharacterString>note two</gco:CharacterString>
+      </mmi:maintenanceNote>
+      <mmi:contact>
+        <cit:CI_Responsibility>
+          <cit:role>
+            <cit:CI_RoleCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_RoleCode" codeListValue="custodian" codeSpace="002"/>
+          </cit:role>
+          <cit:extent/>
+          <cit:party>
+            <cit:CI_Individual>
+              <cit:name>
+                <gco:CharacterString>person name three</gco:CharacterString>
+              </cit:name>
+              <cit:contactInfo/>
+              <cit:partyIdentifier>
+                <mcc:MD_Identifier>
+                  <mcc:authority/>
+                  <mcc:code>
+                    <gco:CharacterString>CID003</gco:CharacterString>
+                  </mcc:code>
+                  <mcc:codeSpace/>
+                  <mcc:version/>
+                  <mcc:description/>
+                </mcc:MD_Identifier>
+              </cit:partyIdentifier>
+              <cit:positionName/>
+            </cit:CI_Individual>
+          </cit:party>
+        </cit:CI_Responsibility>
+      </mmi:contact>
+      <mmi:contact>
+        <cit:CI_Responsibility>
+          <cit:role>
+            <cit:CI_RoleCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_RoleCode" codeListValue="rightHolder" codeSpace="userCode"/>
+          </cit:role>
+          <cit:extent/>
+          <cit:party>
+            <cit:CI_Organisation>
+              <cit:name>
+                <gco:CharacterString>organization name four</gco:CharacterString>
+              </cit:name>
+              <cit:contactInfo/>
+              <cit:partyIdentifier>
+                <mcc:MD_Identifier>
+                  <mcc:authority/>
+                  <mcc:code>
+                    <gco:CharacterString>CID004</gco:CharacterString>
+                  </mcc:code>
+                  <mcc:codeSpace/>
+                  <mcc:version/>
+                  <mcc:description/>
+                </mcc:MD_Identifier>
+              </cit:partyIdentifier>
+              <cit:logo/>
+              <cit:individual/>
+            </cit:CI_Organisation>
+          </cit:party>
+        </cit:CI_Responsibility>
+      </mmi:contact>
+    </mmi:MD_MaintenanceInformation>
+  </mdb:metadataMaintenance>
+
 </mdb:MD_Metadata>


### PR DESCRIPTION
related to [#4639](https://github.com/GSA/data.gov/issues/4639)

- Add identifier, landing page, system of record, describe by type, accrual periodicity, and primary IT investment UII iso to dcatus tests
- add maintenance module and test
- update some xpaths and comments