### PR TITLE
add additionalResource transformation

### DIFF
--- a/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_aggregation_info.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_aggregation_info.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+require 'adiwg/mdtranslator/internal/internal_metadata_obj'
+require_relative 'module_citation'
+
+module ADIWG
+   module Mdtranslator
+      module Readers
+         module Iso191152
+            module AggregationInformation
+               @@mdAggregationInfoXPath = 'gmd:MD_AggregateInformation'
+               @@aggDatasetNameXPath = 'gmd:aggregateDataSetName'
+               def self.unpack(xAggregrationInfo, hResponseObj)
+                  intMetadataClass = InternalMetadata.new
+                  hAggInfo = intMetadataClass.newAssociatedResource
+
+                  xMDAggregationInfo = xAggregrationInfo.xpath(@@mdAggregationInfoXPath)[0]
+
+                  return nil if xMDAggregationInfo.nil?
+
+                  # :resourceCitation (optional)
+                  # <xs:element name="aggregateDataSetName" type="gmd:CI_Citation_PropertyType" minOccurs="0"/>
+                  xAggDatasetName = xMDAggregationInfo.xpath(@@aggDatasetNameXPath)[0]
+                  unless xAggDatasetName.nil?
+                     hAggInfo[:resourceCitation] =
+                        Citation.unpack(xAggDatasetName, hResponseObj)
+                  end
+
+                  hAggInfo
+               end
+            end
+         end
+      end
+   end
+end

--- a/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_citation.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_citation.rb
@@ -75,8 +75,9 @@ module ADIWG
                   # onlineResource (optional)
                   # <xs:element name="onlineResource" type="gmd:CI_OnlineResource_PropertyType" minOccurs="0"/>
                   xOnlineResource = xCitation.xpath(@@onlineResourceXPath)[0]
-                  hCitation[:onlineResources] = xOnlineResource.nil? ? nil : [OnlineResource.unpack(xOnlineResource, hResponseObj)]
-                  
+                  hCitation[:onlineResources] =
+                     xOnlineResource.nil? ? nil : [OnlineResource.unpack(xOnlineResource, hResponseObj)]
+
                   hCitation
                end
             end

--- a/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_metadata.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_metadata.rb
@@ -4,6 +4,7 @@ require 'nokogiri'
 require 'adiwg/mdtranslator/internal/internal_metadata_obj'
 require_relative 'module_resource_info'
 require_relative 'module_metadata_info'
+require_relative 'module_aggregation_info'
 
 module ADIWG
    module Mdtranslator
@@ -12,6 +13,7 @@ module ADIWG
             module Metadata
                @@identificationInfoXPath = 'gmd:identificationInfo'
                @@dataIdentificationXPath = 'gmd:MD_DataIdentification'
+               @@aggregationInfoXPath = 'gmd:identificationInfo//gmd:MD_DataIdentification//gmd:aggregationInfo'
                def self.unpack(xMetadata, hResponseObj)
                   intMetadataClass = InternalMetadata.new
                   intMetadata = intMetadataClass.newMetadata
@@ -45,8 +47,16 @@ module ADIWG
 
                   intMetadata[:metadataInfo] = MetadataInformation.unpack(xMetadata, hResponseObj)
 
+                  # :associatedResources (optional)
+                  # <xs:element name="aggregationInfo" type="gmd:MD_AggregateInformation_PropertyType"
+                  # minOccurs="0" maxOccurs="unbounded"/>
+                  xAggregationInfos = xMetadata.xpath(@@aggregationInfoXPath)
+                  intMetadata[:associatedResources] = xAggregationInfos.map do |a|
+                     AggregationInformation.unpack(a, hResponseObj)
+                  end
+                  intMetadata[:associatedResources] = intMetadata[:associatedResources].compact
+
                   # :distributorInfo
-                  # :associatedResources
                   # :additionalDocuments
                   # :lineageInfo
                   # :additionalDocuments

--- a/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_online_resource.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_online_resource.rb
@@ -15,7 +15,6 @@ module ADIWG
                @@nameXPath = 'gmd:name//gco:CharacterString'
                @@descXPath = 'gmd:description//gco:CharacterString'
                @@funcXPath = 'gmd:function//gmd:CI_OnLineFunctionCode'
-               @@protocolReqXPath = 'gmd:protocolRequest//gco:CharacterString'
                def self.unpack(xParent, _hResponseObj)
                   # xParent because an online resource can occur within
                   # mcc:linkage or gmd:onlineResource
@@ -26,33 +25,36 @@ module ADIWG
 
                   return nil if xCiOnelineResource.empty?
 
-                  # :olResURI (optional)
+                  # :olResURI (required)
+                  # <xs:element name="linkage" type="gmd:URL_PropertyType"/>
                   xLink = xCiOnelineResource.xpath(@@linkageXPath)
                   hOnlineResource[:olResURI] = xLink.empty? ? nil : xLink[0].text
 
                   # :olResName (optional)
+                  # <xs:element name="name" type="gco:CharacterString_PropertyType" minOccurs="0"/>
                   xName = xCiOnelineResource.xpath(@@nameXPath)
                   hOnlineResource[:olResName] = xName.empty? ? nil : xName[0].text
 
                   # :olResDesc (optional)
+                  # <xs:element name="description" type="gco:CharacterString_PropertyType" minOccurs="0"/>
                   xDesc = xCiOnelineResource.xpath(@@descXPath)
                   hOnlineResource[:olResDesc] = xDesc.empty? ? nil : xDesc[0].text
 
                   # :olResFunction (optional)
+                  # <xs:element name="function" type="gmd:CI_OnLineFunctionCode_PropertyType" minOccurs="0"/>
                   xFunc = xCiOnelineResource.xpath(@@funcXPath)
                   hOnlineResource[:olResFunction] = xFunc.empty? ? nil : xFunc[0].attr('codeListValue')
 
                   # :olResApplicationProfile (optional)
+                  # # <xs:element name="applicationProfile" type="gco:CharacterString_PropertyType" minOccurs="0"/>
                   xAppProfile = xCiOnelineResource.xpath(@@appProfileXPath)
                   hOnlineResource[:olResApplicationProfile] = xAppProfile.empty? ? nil : xAppProfile[0].text
 
                   # :olResProtocol (optional)
+                  # <xs:element name="protocol" type="gco:CharacterString_PropertyType" minOccurs="0"/>
                   xProtocol = xCiOnelineResource.xpath(@@protocolXPath)
                   hOnlineResource[:olResProtocol] = xProtocol.empty? ? nil : xProtocol[0].text
 
-                  # :olResProtocolRequest (optional)
-                  xProtocolReq = xCiOnelineResource.xpath(@@protocolReqXPath)
-                  hOnlineResource[:olResProtocolRequest] = xProtocolReq.empty? ? nil : xProtocolReq[0].text
                   hOnlineResource
                end
             end

--- a/test/readers/iso19115_2/tc_iso19115_2_aggregation_info.rb
+++ b/test/readers/iso19115_2/tc_iso19115_2_aggregation_info.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# MdTranslator - minitest of
+# readers / iso19115-2 / module_aggregation_info
+
+require 'adiwg/mdtranslator/readers/iso19115_2/modules/module_aggregation_info'
+require_relative 'iso19115_2_test_parent'
+require 'debug'
+
+class TestReaderIso191152AggregationInformation < TestReaderIso191152Parent
+   @@nameSpace = ADIWG::Mdtranslator::Readers::Iso191152::AggregationInformation
+
+   def test_aggregation_info_complete
+      xDoc = TestReaderIso191152Parent.get_xml('iso19115-2.xml')
+      TestReaderIso191152Parent.set_xdoc(xDoc)
+
+      xIn = xDoc.xpath('.//gmd:aggregationInfo')[0]
+      hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
+      hDictionary = @@nameSpace.unpack(xIn, hResponse)
+
+      refute_empty hDictionary
+      assert hDictionary.instance_of? Hash
+      refute_empty hDictionary[:resourceCitation]
+   end
+end

--- a/test/readers/iso19115_2/tc_iso19115_3_online_resource.rb
+++ b/test/readers/iso19115_2/tc_iso19115_3_online_resource.rb
@@ -25,6 +25,5 @@ class TestReaderIso191152OnlineResource < TestReaderIso191152Parent
       assert_equal('information', onlineResource[:olResFunction])
       assert_equal('online resource application profile', onlineResource[:olResApplicationProfile])
       assert_equal('WWW:LINK-1.0-http--link', onlineResource[:olResProtocol])
-      assert_equal('online resource protocol request', onlineResource[:olResProtocolRequest])
    end
 end

--- a/test/readers/iso19115_2/testData/iso19115-2.xml
+++ b/test/readers/iso19115_2/testData/iso19115-2.xml
@@ -125,9 +125,6 @@
                             <gmd:applicationProfile>
                               <gco:CharacterString>online resource application profile</gco:CharacterString>
                             </gmd:applicationProfile>
-                            <gmd:protocolRequest>
-                              <gco:CharacterString>online resource protocol request</gco:CharacterString>
-                            </gmd:protocolRequest>
                             <gmd:function>
                               <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
                             </gmd:function>
@@ -338,7 +335,175 @@
          </gmd:MD_Constraints>
       </gmd:resourceConstraints>
 
-      <gmd:aggregationInfo/>
+      <gmd:aggregationInfo>
+         <gmd:MD_AggregateInformation>
+            <gmd:aggregateDataSetName>
+               <gmd:CI_Citation>
+                  <gmd:title>
+                     <gco:CharacterString>associated resource title 1</gco:CharacterString>
+                  </gmd:title>
+                  <gmd:alternateTitle/>
+                  <gmd:date>
+                     <gmd:CI_Date>
+                     <gmd:date>
+                        <gco:Date>2017-11-22</gco:Date>
+                     </gmd:date>
+                     <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_DateTypeCode" codeListValue="publication" codeSpace="002"/>
+                     </gmd:dateType>
+                     </gmd:CI_Date>
+                  </gmd:date>
+                  <gmd:edition/>
+                  <gmd:identifier/>
+                  <gmd:citedResponsibleParty>
+                     <gmd:CI_ResponsibleParty>
+                     <gmd:individualName>
+                        <gco:CharacterString>person name three</gco:CharacterString>
+                     </gmd:individualName>
+                     <gmd:positionName/>
+                     <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                           <gmd:phone>
+                              <gmd:CI_Telephone>
+                              <gmd:voice>
+                                 <gco:CharacterString>phone name: 222-222-2222</gco:CharacterString>
+                              </gmd:voice>
+                              <gmd:facsimile/>
+                              </gmd:CI_Telephone>
+                           </gmd:phone>
+                           <gmd:address/>
+                           <gmd:onlineResource>
+                              <gmd:CI_OnlineResource>
+                                 <gmd:linkage>
+                                    <gmd:URL>aggregate_information_online_resources</gmd:URL>
+                                 </gmd:linkage>
+                                 <gmd:protocol>
+                                    <gco:CharacterString>WWW:LINK-6.0-https--link</gco:CharacterString>
+                                 </gmd:protocol>
+                                 <gmd:name>
+                                    <gco:CharacterString>name of aggregate information resource</gco:CharacterString>
+                                 </gmd:name>
+                                 <gmd:description>
+                                    <gco:CharacterString>aggregate information detailed description</gco:CharacterString>
+                                 </gmd:description>
+                                 <gmd:applicationProfile>
+                                    <gco:CharacterString>agg app profile</gco:CharacterString>
+                                 </gmd:applicationProfile>
+                                 <gmd:function>
+                                    <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
+                                 </gmd:function>
+                              </gmd:CI_OnlineResource>
+                           </gmd:onlineResource>
+
+                           <gmd:hoursOfService/>
+                           <gmd:contactInstructions/>
+                        </gmd:CI_Contact>
+                     </gmd:contactInfo>
+                     <gmd:role>
+                        <gmd:CI_RoleCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_RoleCode" codeListValue="originator" codeSpace="006"/>
+                     </gmd:role>
+                     </gmd:CI_ResponsibleParty>
+                  </gmd:citedResponsibleParty>
+                  <gmd:presentationForm/>
+                  <gmd:series/>
+                  <gmd:otherCitationDetails/>
+                  <gmd:ISBN/>
+                  <gmd:ISSN/>
+               </gmd:CI_Citation>
+            </gmd:aggregateDataSetName>
+            <gmd:associationType>
+            <gmd:DS_AssociationTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#DS_AssociationTypeCode" codeListValue="largerWorkCitation" codeSpace="002"/>
+            </gmd:associationType>
+            <gmd:initiativeType>
+            <gmd:DS_InitiativeTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#DS_InitiativeTypeCode" codeListValue="initiative type" codeSpace="userCode"/>
+            </gmd:initiativeType>
+         </gmd:MD_AggregateInformation>
+      </gmd:aggregationInfo>
+
+      <gmd:aggregationInfo>
+         <gmd:MD_AggregateInformation>
+            <gmd:aggregateDataSetName>
+               <gmd:CI_Citation>
+                  <gmd:title>
+                     <gco:CharacterString>associated resource title 2</gco:CharacterString>
+                  </gmd:title>
+                  <gmd:alternateTitle/>
+                  <gmd:date>
+                     <gmd:CI_Date>
+                     <gmd:date>
+                        <gco:Date>2017-11-22</gco:Date>
+                     </gmd:date>
+                     <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_DateTypeCode" codeListValue="publication" codeSpace="002"/>
+                     </gmd:dateType>
+                     </gmd:CI_Date>
+                  </gmd:date>
+                  <gmd:edition/>
+                  <gmd:identifier/>
+                  <gmd:citedResponsibleParty>
+                     <gmd:CI_ResponsibleParty>
+                     <gmd:individualName>
+                        <gco:CharacterString>person name three</gco:CharacterString>
+                     </gmd:individualName>
+                     <gmd:positionName/>
+                     <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                           <gmd:phone>
+                              <gmd:CI_Telephone>
+                              <gmd:voice>
+                                 <gco:CharacterString>phone name: 222-222-2222</gco:CharacterString>
+                              </gmd:voice>
+                              <gmd:facsimile/>
+                              </gmd:CI_Telephone>
+                           </gmd:phone>
+                           <gmd:address/>
+                           <gmd:onlineResource>
+                              <gmd:CI_OnlineResource>
+                                 <gmd:linkage>
+                                    <gmd:URL>aggregate_information_online_resources 12309u</gmd:URL>
+                                 </gmd:linkage>
+                                 <gmd:protocol>
+                                    <gco:CharacterString>WWW:LINK-6.0-https--link aoisd</gco:CharacterString>
+                                 </gmd:protocol>
+                                 <gmd:name>
+                                    <gco:CharacterString>name of aggregate information resource 10923j</gco:CharacterString>
+                                 </gmd:name>
+                                 <gmd:description>
+                                    <gco:CharacterString>aggregate information detailed description aoisd</gco:CharacterString>
+                                 </gmd:description>
+                                 <gmd:applicationProfile>
+                                    <gco:CharacterString>agg app profile aisdoih </gco:CharacterString>
+                                 </gmd:applicationProfile>
+                                 <gmd:function>
+                                    <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
+                                 </gmd:function>
+                              </gmd:CI_OnlineResource>
+                           </gmd:onlineResource>
+                           <gmd:hoursOfService/>
+                           <gmd:contactInstructions/>
+                        </gmd:CI_Contact>
+                     </gmd:contactInfo>
+                     <gmd:role>
+                        <gmd:CI_RoleCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_RoleCode" codeListValue="originator" codeSpace="006"/>
+                     </gmd:role>
+                     </gmd:CI_ResponsibleParty>
+                  </gmd:citedResponsibleParty>
+                  <gmd:presentationForm/>
+                  <gmd:series/>
+                  <gmd:otherCitationDetails/>
+                  <gmd:ISBN/>
+                  <gmd:ISSN/>
+               </gmd:CI_Citation>
+            </gmd:aggregateDataSetName>
+            <gmd:associationType>
+            <gmd:DS_AssociationTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#DS_AssociationTypeCode" codeListValue="product" codeSpace="adiwg007"/>
+            </gmd:associationType>
+            <gmd:initiativeType>
+            <gmd:DS_InitiativeTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#DS_InitiativeTypeCode" codeListValue="initiative type" codeSpace="userCode"/>
+            </gmd:initiativeType>
+         </gmd:MD_AggregateInformation>
+      </gmd:aggregationInfo>
+
       <gmd:taxonomy/>
       <gmd:spatialRepresentationType/>
       <gmd:spatialResolution/>

--- a/test/translator/tc_iso19115_2_to_dcatus.rb
+++ b/test/translator/tc_iso19115_2_to_dcatus.rb
@@ -95,12 +95,6 @@ class TestIso191152DcatusTranslation < Minitest::Test
       assert_equal(DateTime.iso8601('2017-01-01T00:00:00+00:00'), res)
    end
 
-   def test_theme
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Theme
-      res = dcatusNS.build(@@intMetadata)
-      assert_equal('biota farming', res)
-   end
-
    def test_identifier
       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Identifier
       res = dcatusNS.build(@@intMetadata)
@@ -120,6 +114,20 @@ class TestIso191152DcatusTranslation < Minitest::Test
       res = dcatusNS.build(@@intMetadata)
 
       assert_equal('ISO19115-2-ID-123456-parent', res)
+   end
+
+   def test_theme
+      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Theme
+      res = dcatusNS.build(@@intMetadata)
+      assert_equal('biota farming', res)
+   end
+
+   def test_references
+      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::References
+      res = dcatusNS.build(@@intMetadata)
+
+      expected = 'aggregate_information_online_resources,aggregate_information_online_resources 12309u'
+      assert_equal(expected, res)
    end
 
    def test_landing_page

--- a/test/translator/testData/iso19115-2.xml
+++ b/test/translator/testData/iso19115-2.xml
@@ -66,7 +66,7 @@
             </gmd:date>
             <gmd:edition/>
             <gmd:identifier/>
-
+            
             <gmd:citedResponsibleParty>
                <gmd:CI_ResponsibleParty>
                   <gmd:organisationName>
@@ -107,7 +107,30 @@
                               </gmd:electronicMailAddress>
                            </gmd:CI_Address>
                         </gmd:address>
-                        <gmd:onlineResource/>
+
+                        <gmd:onlineResource>
+                          <gmd:CI_OnlineResource>
+                            <gmd:linkage>
+                              <gmd:URL>https://online_resource_url.gov</gmd:URL>
+                            </gmd:linkage>
+                            <gmd:protocol>
+                              <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                            </gmd:protocol>
+                            <gmd:name>
+                              <gco:CharacterString>online resource name</gco:CharacterString>
+                            </gmd:name>
+                            <gmd:description>
+                              <gco:CharacterString>online resource description</gco:CharacterString>
+                            </gmd:description>
+                            <gmd:applicationProfile>
+                              <gco:CharacterString>online resource application profile</gco:CharacterString>
+                            </gmd:applicationProfile>
+                            <gmd:function>
+                              <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
+                            </gmd:function>
+                          </gmd:CI_OnlineResource>
+                        </gmd:onlineResource>
+
                         <gmd:hoursOfService/>
                         <gmd:contactInstructions/>
                      </gmd:CI_Contact>
@@ -277,7 +300,7 @@
           </gmd:handlingDescription>
         </gmd:MD_SecurityConstraints>
       </gmd:resourceConstraints>
-
+      
       <gmd:resourceConstraints>
         <gmd:MD_SecurityConstraints>
           <gmd:useLimitation>
@@ -312,7 +335,175 @@
          </gmd:MD_Constraints>
       </gmd:resourceConstraints>
 
-      <gmd:aggregationInfo/>
+      <gmd:aggregationInfo>
+         <gmd:MD_AggregateInformation>
+            <gmd:aggregateDataSetName>
+               <gmd:CI_Citation>
+                  <gmd:title>
+                     <gco:CharacterString>associated resource title 1</gco:CharacterString>
+                  </gmd:title>
+                  <gmd:alternateTitle/>
+                  <gmd:date>
+                     <gmd:CI_Date>
+                     <gmd:date>
+                        <gco:Date>2017-11-22</gco:Date>
+                     </gmd:date>
+                     <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_DateTypeCode" codeListValue="publication" codeSpace="002"/>
+                     </gmd:dateType>
+                     </gmd:CI_Date>
+                  </gmd:date>
+                  <gmd:edition/>
+                  <gmd:identifier/>
+                  <gmd:citedResponsibleParty>
+                     <gmd:CI_ResponsibleParty>
+                     <gmd:individualName>
+                        <gco:CharacterString>person name three</gco:CharacterString>
+                     </gmd:individualName>
+                     <gmd:positionName/>
+                     <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                           <gmd:phone>
+                              <gmd:CI_Telephone>
+                              <gmd:voice>
+                                 <gco:CharacterString>phone name: 222-222-2222</gco:CharacterString>
+                              </gmd:voice>
+                              <gmd:facsimile/>
+                              </gmd:CI_Telephone>
+                           </gmd:phone>
+                           <gmd:address/>
+                           <gmd:onlineResource>
+                              <gmd:CI_OnlineResource>
+                                 <gmd:linkage>
+                                    <gmd:URL>aggregate_information_online_resources</gmd:URL>
+                                 </gmd:linkage>
+                                 <gmd:protocol>
+                                    <gco:CharacterString>WWW:LINK-6.0-https--link</gco:CharacterString>
+                                 </gmd:protocol>
+                                 <gmd:name>
+                                    <gco:CharacterString>name of aggregate information resource</gco:CharacterString>
+                                 </gmd:name>
+                                 <gmd:description>
+                                    <gco:CharacterString>aggregate information detailed description</gco:CharacterString>
+                                 </gmd:description>
+                                 <gmd:applicationProfile>
+                                    <gco:CharacterString>agg app profile</gco:CharacterString>
+                                 </gmd:applicationProfile>
+                                 <gmd:function>
+                                    <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
+                                 </gmd:function>
+                              </gmd:CI_OnlineResource>
+                           </gmd:onlineResource>
+
+                           <gmd:hoursOfService/>
+                           <gmd:contactInstructions/>
+                        </gmd:CI_Contact>
+                     </gmd:contactInfo>
+                     <gmd:role>
+                        <gmd:CI_RoleCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_RoleCode" codeListValue="originator" codeSpace="006"/>
+                     </gmd:role>
+                     </gmd:CI_ResponsibleParty>
+                  </gmd:citedResponsibleParty>
+                  <gmd:presentationForm/>
+                  <gmd:series/>
+                  <gmd:otherCitationDetails/>
+                  <gmd:ISBN/>
+                  <gmd:ISSN/>
+               </gmd:CI_Citation>
+            </gmd:aggregateDataSetName>
+            <gmd:associationType>
+            <gmd:DS_AssociationTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#DS_AssociationTypeCode" codeListValue="largerWorkCitation" codeSpace="002"/>
+            </gmd:associationType>
+            <gmd:initiativeType>
+            <gmd:DS_InitiativeTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#DS_InitiativeTypeCode" codeListValue="initiative type" codeSpace="userCode"/>
+            </gmd:initiativeType>
+         </gmd:MD_AggregateInformation>
+      </gmd:aggregationInfo>
+
+      <gmd:aggregationInfo>
+         <gmd:MD_AggregateInformation>
+            <gmd:aggregateDataSetName>
+               <gmd:CI_Citation>
+                  <gmd:title>
+                     <gco:CharacterString>associated resource title 2</gco:CharacterString>
+                  </gmd:title>
+                  <gmd:alternateTitle/>
+                  <gmd:date>
+                     <gmd:CI_Date>
+                     <gmd:date>
+                        <gco:Date>2017-11-22</gco:Date>
+                     </gmd:date>
+                     <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_DateTypeCode" codeListValue="publication" codeSpace="002"/>
+                     </gmd:dateType>
+                     </gmd:CI_Date>
+                  </gmd:date>
+                  <gmd:edition/>
+                  <gmd:identifier/>
+                  <gmd:citedResponsibleParty>
+                     <gmd:CI_ResponsibleParty>
+                     <gmd:individualName>
+                        <gco:CharacterString>person name three</gco:CharacterString>
+                     </gmd:individualName>
+                     <gmd:positionName/>
+                     <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                           <gmd:phone>
+                              <gmd:CI_Telephone>
+                              <gmd:voice>
+                                 <gco:CharacterString>phone name: 222-222-2222</gco:CharacterString>
+                              </gmd:voice>
+                              <gmd:facsimile/>
+                              </gmd:CI_Telephone>
+                           </gmd:phone>
+                           <gmd:address/>
+                           <gmd:onlineResource>
+                              <gmd:CI_OnlineResource>
+                                 <gmd:linkage>
+                                    <gmd:URL>aggregate_information_online_resources 12309u</gmd:URL>
+                                 </gmd:linkage>
+                                 <gmd:protocol>
+                                    <gco:CharacterString>WWW:LINK-6.0-https--link aoisd</gco:CharacterString>
+                                 </gmd:protocol>
+                                 <gmd:name>
+                                    <gco:CharacterString>name of aggregate information resource 10923j</gco:CharacterString>
+                                 </gmd:name>
+                                 <gmd:description>
+                                    <gco:CharacterString>aggregate information detailed description aoisd</gco:CharacterString>
+                                 </gmd:description>
+                                 <gmd:applicationProfile>
+                                    <gco:CharacterString>agg app profile aisdoih </gco:CharacterString>
+                                 </gmd:applicationProfile>
+                                 <gmd:function>
+                                    <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
+                                 </gmd:function>
+                              </gmd:CI_OnlineResource>
+                           </gmd:onlineResource>
+                           <gmd:hoursOfService/>
+                           <gmd:contactInstructions/>
+                        </gmd:CI_Contact>
+                     </gmd:contactInfo>
+                     <gmd:role>
+                        <gmd:CI_RoleCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_RoleCode" codeListValue="originator" codeSpace="006"/>
+                     </gmd:role>
+                     </gmd:CI_ResponsibleParty>
+                  </gmd:citedResponsibleParty>
+                  <gmd:presentationForm/>
+                  <gmd:series/>
+                  <gmd:otherCitationDetails/>
+                  <gmd:ISBN/>
+                  <gmd:ISSN/>
+               </gmd:CI_Citation>
+            </gmd:aggregateDataSetName>
+            <gmd:associationType>
+            <gmd:DS_AssociationTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#DS_AssociationTypeCode" codeListValue="product" codeSpace="adiwg007"/>
+            </gmd:associationType>
+            <gmd:initiativeType>
+            <gmd:DS_InitiativeTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#DS_InitiativeTypeCode" codeListValue="initiative type" codeSpace="userCode"/>
+            </gmd:initiativeType>
+         </gmd:MD_AggregateInformation>
+      </gmd:aggregationInfo>
+
       <gmd:taxonomy/>
       <gmd:spatialRepresentationType/>
       <gmd:spatialResolution/>


### PR DESCRIPTION
related to [#4908](https://github.com/GSA/data.gov/issues/4908)

- add aggregate information processing 
- add documentation and reorganize tests in iso19115-2-to-dcatus translation
- removed  `hOnlineResource[:olResProtocolRequest]` because it's not expected in `onlineResource` for -2. 