### PR TITLE
Iso19115 2 temporal extent fix

### DIFF
--- a/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_temporal_extent.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_temporal_extent.rb
@@ -10,18 +10,27 @@ module ADIWG
          module Iso191152
             module TemporalExtent
                @@temporalExtXPath = 'gmd:EX_TemporalExtent'
-               @@timePeriodXPath = './/gml:TimePeriod'
+               @@timePeriodExtXPath = 'gmd:extent'
                def self.unpack(xtemporalelem, hResponseObj)
                   intMetadataClass = InternalMetadata.new
                   hTemporalExt = intMetadataClass.newTemporalExtent
 
+                  # :EX_TemporalExtent (optional)
+                  # <xs:sequence minOccurs="0"> <xs:element ref="gmd:EX_TemporalExtent"/> </xs:sequence>
                   xTemporalExt = xtemporalelem.xpath(@@temporalExtXPath)[0]
                   return nil if xTemporalExt.nil?
 
-                  # :timePeriod
-                  # <sequence minOccurs="0"> <element ref="gml:TimePeriod"/> </sequence>
-                  xTimePeriod = xTemporalExt.xpath(@@timePeriodXPath)[0]
-                  hTemporalExt[:timePeriod] = TimePeriod.unpack(xTimePeriod, hResponseObj) unless xTimePeriod.nil?
+                  # :extent (required)
+                  # <xs:element name="extent" type="gts:TM_Primitive_PropertyType"/>
+                  xTimePeriodExt = xTemporalExt.xpath(@@timePeriodExtXPath)[0]
+                  if xTimePeriodExt.nil?
+                     msg = "ERROR: ISO19115-2 reader: Element gmd:extent is missing in gmd:EX_TemporalExtent"
+                     hResponseObj[:readerExecutionMessages] << msg
+                     hResponseObj[:readerExecutionPass] = false
+                     return nil
+                  end
+
+                  hTemporalExt[:timePeriod] = TimePeriod.unpack(xTimePeriodExt, hResponseObj)
 
                   hTemporalExt
                end

--- a/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_time_period.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_time_period.rb
@@ -8,20 +8,18 @@ module ADIWG
       module Readers
          module Iso191152
             module TimePeriod
+               @@timePeriodXPath = 'gml:TimePeriod'
                @@idAttr = 'gml:id'
                @@beginPosXPath = 'gml:beginPosition | gml:begin'
                @@endPosXPath = 'gml:endPosition | gml:end'
-               def self.unpack(xTimePeriod, hResponseObj)
+               def self.unpack(xTimePeriodExt, hResponseObj)
                   intMetadataClass = InternalMetadata.new
                   hTimePeriod = intMetadataClass.newTimePeriod
 
-                  timeId = xTimePeriod.attr(@@idAttr)
-                  if timeId.nil?
-                     msg = 'ERROR: ISO19115-2 reader: Attribut gml:id is missing in gml:TimePeriod'
-                     hResponseObj[:readerExecutionMessages] << msg
-                  end
-
-                  hTimePeriod[:timeId] = timeId
+                  # :timeperod (optional)
+                  # <sequence minOccurs="0"> <element ref="gml:TimePeriod"/> </sequence>
+                  xTimePeriod = xTimePeriodExt.xpath(@@timePeriodXPath)
+                  return nil if xTimePeriod.nil? # to-do: report an error?
                   
                   # :beginPosition/:begin and :endPosition/:end
                   # <sequence>
@@ -45,6 +43,8 @@ module ADIWG
                      msg = 'ERROR: ISO19115-2 reader: Element gml:beginPosition or gml:begin '\
                            'is missing in gml:TimePeriod'
                      hResponseObj[:readerExecutionMessages] << msg
+                     hResponseObj[:readerExecutionPass] = false
+                     return nil
                   end
                   hTimePeriod[:startDateTime] = startDatetime
 
@@ -58,6 +58,8 @@ module ADIWG
                      msg = 'ERROR: ISO19115-2 reader: Element gml:endPosition or gml:end '\
                            'is missing in gml:TimePeriod'
                      hResponseObj[:readerExecutionMessages] << msg
+                     hResponseObj[:readerExecutionPass] = false
+                     return nil
                   end
                   hTimePeriod[:endDateTime] = endDatetime
 

--- a/test/readers/iso19115_2/tc_iso19115_2_temporal_extent.rb
+++ b/test/readers/iso19115_2/tc_iso19115_2_temporal_extent.rb
@@ -7,17 +7,31 @@ require 'adiwg/mdtranslator/readers/iso19115_2/modules/module_temporal_extent'
 require_relative 'iso19115_2_test_parent'
 
 class TestReaderIso191152TemporalExtent < TestReaderIso191152Parent
-   @@xDoc = TestReaderIso191152Parent.get_xml('iso19115-2.xml')
    @@nameSpace = ADIWG::Mdtranslator::Readers::Iso191152::TemporalExtent
 
    def test_temporal_extent_complete
-      TestReaderIso191152Parent.set_xdoc(@@xDoc)
+      xDoc = TestReaderIso191152Parent.get_xml('iso19115-2.xml')
+      TestReaderIso191152Parent.set_xdoc(xDoc)
 
-      xIn = @@xDoc.xpath('.//gmd:temporalElement')[0]
+      xIn = xDoc.xpath('.//gmd:temporalElement')[0]
       hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
       hDictionary = @@nameSpace.unpack(xIn, hResponse)
 
       refute_empty hDictionary
       refute_empty hDictionary[:timePeriod]
    end
+
+   def test_no_extent
+      xDoc = TestReaderIso191152Parent.get_xml('iso19115-2_no_temporal_extent.xml')
+      TestReaderIso191152Parent.set_xdoc(xDoc)
+
+      xIn = xDoc.xpath('.//gmd:temporalElement')[0]
+      hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
+      hDictionary = @@nameSpace.unpack(xIn, hResponse)
+
+      assert_equal(["ERROR: ISO19115-2 reader: Element gmd:extent is missing in gmd:EX_TemporalExtent"],
+                  hResponse[:readerExecutionMessages])
+      assert_equal(false, hResponse[:readerExecutionPass])
+   end
+
 end

--- a/test/readers/iso19115_2/tc_iso19115_2_time_period.rb
+++ b/test/readers/iso19115_2/tc_iso19115_2_time_period.rb
@@ -13,35 +13,43 @@ class TestReaderIso191152TimePeriod < TestReaderIso191152Parent
       xDoc = TestReaderIso191152Parent.get_xml('iso19115-2.xml')
       TestReaderIso191152Parent.set_xdoc(xDoc)
 
-      xIn = xDoc.xpath('.//gml:TimePeriod')[0]
-
+      xIn = xDoc.xpath('//gmd:EX_TemporalExtent/gmd:extent')[0]
       hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
       hDictionary = @@nameSpace.unpack(xIn, hResponse)
 
       refute_empty hDictionary
-      assert_equal('timePeriod_001', hDictionary[:timeId])
       assert_equal({ dateTime: '2017-12-01T00:00:00+00:00', dateResolution: 'YMDhms' },
                    hDictionary[:startDateTime])
       assert_equal({ dateTime: '2023-12-01T00:00:00+00:00', dateResolution: 'YMDhms' },
                    hDictionary[:endDateTime])
    end
 
-   def test_no_time_period
+   def test_no_time_period_begin
       xDoc = TestReaderIso191152Parent.get_xml('iso19115-2_no_temporal_timeperiod.xml')
       TestReaderIso191152Parent.set_xdoc(xDoc)
 
-      warnings = [
-         "ERROR: ISO19115-2 reader: Attribut gml:id is missing in gml:TimePeriod",
-         "ERROR: ISO19115-2 reader: Element gml:beginPosition or gml:begin is missing in gml:TimePeriod",
-         "ERROR: ISO19115-2 reader: Element gml:endPosition or gml:end is missing in gml:TimePeriod"
-       ]
+      xIn = xDoc.xpath('.//gmd:extent')[0]
+      hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
+      _hDictionary = @@nameSpace.unpack(xIn, hResponse)
 
-       xDoc.xpath('.//gml:TimePeriod').each_with_index do |xIn, index|
-         hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
-         hDictionary = @@nameSpace.unpack(xIn, hResponse)
-         assert_equal([warnings[index]], hResponse[:readerExecutionMessages])
-      end
+      assert_equal(["ERROR: ISO19115-2 reader: Element gml:beginPosition or gml:begin is missing in gml:TimePeriod"],
+                  hResponse[:readerExecutionMessages])
+      assert_equal(false, hResponse[:readerExecutionPass])
+
    end
 
+   def test_no_time_period_end
+      xDoc = TestReaderIso191152Parent.get_xml('iso19115-2_no_temporal_timeperiod.xml')
+      TestReaderIso191152Parent.set_xdoc(xDoc)
+
+      xIn = xDoc.xpath('.//gmd:extent')[1]
+      hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
+      _hDictionary = @@nameSpace.unpack(xIn, hResponse)
+
+      assert_equal(["ERROR: ISO19115-2 reader: Element gml:endPosition or gml:end is missing in gml:TimePeriod"],
+                  hResponse[:readerExecutionMessages])
+      assert_equal(false, hResponse[:readerExecutionPass])
+
+   end
 
 end

--- a/test/readers/iso19115_2/testData/iso19115-2_no_temporal_extent.xml
+++ b/test/readers/iso19115_2/testData/iso19115-2_no_temporal_extent.xml
@@ -24,32 +24,8 @@
           
           <gmd:temporalElement>
             <gmd:EX_TemporalExtent>
-              <gmd:extent>
-                <gml:TimePeriod gml:id="timePeriod_001">
-                  <gml:description>resource time period</gml:description>
-                  <gml:identifier codeSpace=""/>
-                  <gml:name/>
-                  <gml:beginPosition/>
-                  <gml:endPosition>2023-12-01T00:00:00</gml:endPosition>
-                </gml:TimePeriod>
-              </gmd:extent>
             </gmd:EX_TemporalExtent>
           </gmd:temporalElement>
 
-
-
-          <gmd:temporalElement>
-            <gmd:EX_TemporalExtent>
-              <gmd:extent>
-                <gml:TimePeriod gml:id="timePeriod_001">
-                  <gml:description>resource time period</gml:description>
-                  <gml:identifier codeSpace=""/>
-                  <gml:name/>
-                  <gml:begin>2017-12-01T00:00:00</gml:begin>
-                  <gml:end/>
-                </gml:TimePeriod>
-              </gmd:extent>
-            </gmd:EX_TemporalExtent>
-          </gmd:temporalElement>
 
 </gmi:MI_Metadata>


### PR DESCRIPTION
related: https://github.com/GSA/data.gov/issues/4904

Updated the parent of gml:TimePeriod to gmd:extent.
Added and revised test cases.
Removed unused IDs, retaining only essential information for the writer.