### PR TITLE
added Iso19115-2 Language processing to dcatus 

### DIFF
--- a/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_locale.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_locale.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+require 'adiwg/mdtranslator/internal/internal_metadata_obj'
+require 'adiwg-mdcodes'
+
+module ADIWG
+   module Mdtranslator
+      module Readers
+         module Iso191152
+            module Locale
+               @@localeXPath = 'gmd:PT_Locale'
+               @@langCodeXpath = 'gmd:languageCode//gmd:LanguageCode'
+
+               def self.unpack(xLocale, hResponseObj)
+                  intMetadataClass = InternalMetadata.new
+                  hLocale = intMetadataClass.newLocale
+
+                  # :PT_Locale (optional)
+                  # <xs:sequence minOccurs="0"><xs:element ref="gmd:PT_Locale"/></xs:sequence>
+                  xPTLocale = xLocale.xpath(@@localeXPath)[0]
+                  return nil if xPTLocale.nil?
+
+                  # :LanguageCode (optional)
+                  # <xs:sequence minOccurs="0"><xs:element ref="gmd:LanguageCode"/></xs:sequence>
+                  xLocaleLangCode =  xPTLocale.xpath(@@langCodeXpath)
+                  hLocale[:languageCode] = xLocaleLangCode.attr('codeListValue').text unless xLocaleLangCode.nil?
+
+                  hLocale
+               end
+            end
+         end
+      end
+   end
+end

--- a/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_metadata_info.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_metadata_info.rb
@@ -1,7 +1,7 @@
 require 'nokogiri'
 require 'adiwg/mdtranslator/internal/internal_metadata_obj'
 require_relative 'module_maintenance'
-
+require_relative 'module_locale'
 
 module ADIWG
    module Mdtranslator
@@ -11,6 +11,8 @@ module ADIWG
                @@fileIdentifierXPath = 'gmd:fileIdentifier//gco:CharacterString'
                @@parentIdentifierXPath = 'gmd:parentIdentifier//gco:CharacterString'
                @@maintenanceXPath = 'gmd:metadataMaintenance'
+               @@localeXPath = 'gmd:locale'
+
                def self.unpack(xMetadata, hResponseObj)
 
                   # instance classes needed in script
@@ -28,6 +30,11 @@ module ADIWG
                   # <xs:element name="metadataMaintenance" type="gmd:MD_MaintenanceInformation_PropertyType" minOccurs="0"/>
                   xMaintenance = xMetadata.xpath(@@maintenanceXPath)[0]
                   hMetadataInfo[:metadataMaintenance] = Maintenance.unpack(xMaintenance, hResponseObj) unless xMaintenance.nil?
+
+                  # :locale (optional)
+                  # <xs:element name="language" type="gco:CharacterString_PropertyType" minOccurs="0"/>
+                  xLocale = xMetadata.xpath(@@localeXPath)
+                  hMetadataInfo[:defaultMetadataLocale] = Locale.unpack(xLocale, hResponseObj) unless xLocale.nil?
 
                   return hMetadataInfo
 

--- a/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_resource_info.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_resource_info.rb
@@ -19,7 +19,6 @@ module ADIWG
                @@pointOfContactXPath = 'gmd:pointOfContact'
                @@constraintsXPath = 'gmd:resourceConstraints'
                @@extentsXPath = 'gmd:extent'
-
                def self.unpack(xDataIdentification, hResponseObj)
                   intMetadataClass = InternalMetadata.new
                   hResourceInfo = intMetadataClass.newResourceInfo

--- a/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_resource_info.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2/modules/module_resource_info.rb
@@ -19,6 +19,7 @@ module ADIWG
                @@pointOfContactXPath = 'gmd:pointOfContact'
                @@constraintsXPath = 'gmd:resourceConstraints'
                @@extentsXPath = 'gmd:extent'
+
                def self.unpack(xDataIdentification, hResponseObj)
                   intMetadataClass = InternalMetadata.new
                   hResourceInfo = intMetadataClass.newResourceInfo

--- a/test/readers/iso19115_2/tc_iso19115_2_locale.rb
+++ b/test/readers/iso19115_2/tc_iso19115_2_locale.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# MdTranslator - minitest of
+# readers / iso19115-2 / module_locale
+
+require 'adiwg/mdtranslator/readers/iso19115_2/modules/module_locale'
+require_relative 'iso19115_2_test_parent'
+
+class TestReaderIso191152Locale < TestReaderIso191152Parent
+   @@xDoc = TestReaderIso191152Parent.get_xml('iso19115-2.xml')
+   @@nameSpace = ADIWG::Mdtranslator::Readers::Iso191152::Locale
+
+   def test_default_locale_complete
+      TestReaderIso191152Parent.set_xdoc(@@xDoc)
+
+      xIn = @@xDoc.xpath('gmi:MI_Metadata//gmd:locale')[0]
+      hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
+      hDictionary = @@nameSpace.unpack(xIn, hResponse)
+
+      refute_empty hDictionary
+      assert hDictionary.instance_of? Hash
+      assert_equal('eng', hDictionary[:languageCode])
+   end
+
+end

--- a/test/readers/iso19115_2/testData/iso19115-2.xml
+++ b/test/readers/iso19115_2/testData/iso19115-2.xml
@@ -23,6 +23,46 @@
   <gmd:fileIdentifier>
     <gco:CharacterString>ISO19115-2-ID-123456</gco:CharacterString>
   </gmd:fileIdentifier>
+  <gmd:locale>
+    <gmd:PT_Locale>
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#LanguageCode" codeListValue="eng" codeSpace="123"/>
+      </gmd:languageCode>
+      <gmd:country>
+        <gmd:CountryCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CountryCode" codeListValue="FJI" codeSpace="242"/>
+      </gmd:country>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_CharacterSetCode" codeListValue="UTF-16" codeSpace="1015"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale>
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#LanguageCode" codeListValue="fre" codeSpace="137"/>
+      </gmd:languageCode>
+      <gmd:country>
+        <gmd:CountryCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CountryCode" codeListValue="COG" codeSpace="178"/>
+      </gmd:country>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_CharacterSetCode" codeListValue="UTF-16" codeSpace="1015"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale>
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#LanguageCode" codeListValue="spa" codeSpace="401"/>
+      </gmd:languageCode>
+      <gmd:country>
+        <gmd:CountryCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CountryCode" codeListValue="CUB" codeSpace="192"/>
+      </gmd:country>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_CharacterSetCode" codeListValue="UTF-16" codeSpace="1015"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+
   <gmd:parentIdentifier>
     <gco:CharacterString>ISO19115-2-ID-123456-parent</gco:CharacterString>
   </gmd:parentIdentifier>

--- a/test/translator/tc_iso19115_2_to_dcatus.rb
+++ b/test/translator/tc_iso19115_2_to_dcatus.rb
@@ -103,6 +103,13 @@ class TestIso191152DcatusTranslation < Minitest::Test
       assert_equal(DateTime.iso8601('2017-01-01T00:00:00+00:00'), res)
    end
 
+   def test_language
+      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Language
+      res = dcatusNS.build(@@intMetadata)
+
+      assert_equal(%w[eng], res)
+   end
+
    def test_identifier
       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Identifier
       res = dcatusNS.build(@@intMetadata)

--- a/test/translator/testData/iso19115-2.xml
+++ b/test/translator/testData/iso19115-2.xml
@@ -23,6 +23,45 @@
   <gmd:fileIdentifier>
     <gco:CharacterString>ISO19115-2-ID-123456</gco:CharacterString>
   </gmd:fileIdentifier>
+  <gmd:locale>
+    <gmd:PT_Locale>
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#LanguageCode" codeListValue="eng" codeSpace="123"/>
+      </gmd:languageCode>
+      <gmd:country>
+        <gmd:CountryCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CountryCode" codeListValue="FJI" codeSpace="242"/>
+      </gmd:country>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_CharacterSetCode" codeListValue="UTF-16" codeSpace="1015"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale>
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#LanguageCode" codeListValue="fre" codeSpace="137"/>
+      </gmd:languageCode>
+      <gmd:country>
+        <gmd:CountryCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CountryCode" codeListValue="COG" codeSpace="178"/>
+      </gmd:country>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_CharacterSetCode" codeListValue="UTF-16" codeSpace="1015"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale>
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#LanguageCode" codeListValue="spa" codeSpace="401"/>
+      </gmd:languageCode>
+      <gmd:country>
+        <gmd:CountryCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CountryCode" codeListValue="CUB" codeSpace="192"/>
+      </gmd:country>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_CharacterSetCode" codeListValue="UTF-16" codeSpace="1015"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
   <gmd:parentIdentifier>
     <gco:CharacterString>ISO19115-2-ID-123456-parent</gco:CharacterString>
   </gmd:parentIdentifier>


### PR DESCRIPTION
related https://github.com/GSA/data.gov/issues/4888

- added `Language` processing in the  module
- added tests
- added `gmd:locale` in the iso19115_2.xml file. 