### PR TITLE
add minor fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   Include:
     # - lib/adiwg/mdtranslator/readers/iso19115_3/**/*.rb
     - lib/adiwg/mdtranslator/readers/iso19115_2_datagov/**/*.rb
+    - lib/adiwg/mdtranslator/internal/module_utils.rb
     # - test/readers/iso19115_3/**/*.rb
     - test/readers/iso19115_2_datagov/**/*.rb
   Exclude:

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ require 'rake/testtask'
 Rake::TestTask.new do |t|
    t.libs << 'test'
    t.test_files = FileList[
+      'test/internal/*.rb',
       'test/readers/fgdc/tc*.rb',
       'test/readers/iso19115_2/tc*.rb',
       'test/readers/iso19115_2_datagov/tc*.rb',

--- a/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_date.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_date.rb
@@ -39,7 +39,7 @@ module ADIWG
               #   <xs:element ref="gco:Date"/>
               #   <xs:element ref="gco:DateTime"/>
               # </xs:choice>
-              xD = xDateDate.xpath('gco:Date')[0]
+              xD = xDateDate.xpath('gco:Date | gco:DateTime')[0]
 
               if xD.nil? && !AdiwgUtils.valid_nil_reason(xDateDate, hResponseObj)
                 msg = "WARNING: ISO19115-2 reader: element \'#{xDateDate.name}\' "\

--- a/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_keyword.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_keyword.rb
@@ -36,7 +36,7 @@ module ADIWG
                   next
                 end
 
-                keyword = keyword.xpath('gco:CharacterString')[0]
+                keyword = keyword.xpath('gco:CharacterString | gmx:Anchor')[0]
                 next if keyword.nil?
 
                 k = intMetadataClass.newKeywordObject

--- a/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_responsibility.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_responsibility.rb
@@ -72,17 +72,7 @@ module ADIWG
               contactName = xIndividual.text
             end
 
-            if contactName.nil?
-              # TODO: revisit this. this seems like the right decision.
-              # talk to chris about this. can there a responsibility party without an i or o?
-              # this may need to be elevated to an error not a warning.
-              msg = "WARNING: ISO19115-2 reader: \'#{@@responsibilityXPath}\' must have at " \
-              'least an individual or organization. neither are present.'
-              hResponseObj[:readerValidationMessages] << msg
-              hResponseObj[:readerValidationPass] = false
-              # returning nil to not interfere with setting a non-existent contact later
-              return nil
-            else
+            unless contactName.nil?
               hContact[:name] = contactName
               contactId = Iso191152datagov.add_contact(contactName, hContact[:isOrganization])
               hContact[:contactId] = contactId

--- a/test/internal/module_datetime_fun.rb
+++ b/test/internal/module_datetime_fun.rb
@@ -7,25 +7,25 @@ require 'minitest/autorun'
 require 'adiwg/mdtranslator/internal/module_dateTimeFun'
 
 class TestDateTimeFun < Minitest::Test
-   def test_convert_duration_to_named_group
-      tests = [
-         ['P1Y2M3DT10H',
-          { 'sign' => 'P', 'years' => '1', 'months' => '2', 'days' => '3', 'hours' => '10', 'minutes' => nil,
-            'seconds' => nil }],
+  def test_convert_duration_to_named_group
+    tests = [
+      ['P1Y2M3DT10H',
+       { 'sign' => 'P', 'years' => '1', 'months' => '2', 'days' => '3', 'hours' => '10', 'minutes' => nil,
+         'seconds' => nil }],
 
-         ['P1DT12H',
-          { 'sign' => 'P', 'years' => nil, 'months' => nil, 'days' => '1', 'hours' => '12', 'minutes' => nil,
-            'seconds' => nil }],
+      ['P1DT12H',
+       { 'sign' => 'P', 'years' => nil, 'months' => nil, 'days' => '1', 'hours' => '12', 'minutes' => nil,
+         'seconds' => nil }],
 
-         ['hello', nil],
+      ['hello', nil],
 
-         ['P7Y2M9DT8H45M13S',
-          { 'sign' => 'P', 'years' => '7', 'months' => '2', 'days' => '9', 'hours' => '8', 'minutes' => '45',
-            'seconds' => '13' }]
-      ]
+      ['P7Y2M9DT8H45M13S',
+       { 'sign' => 'P', 'years' => '7', 'months' => '2', 'days' => '9', 'hours' => '8', 'minutes' => '45',
+         'seconds' => '13' }]
+    ]
 
-      tests.each do |test|
-         assert_equal(test[1], AdiwgDateTimeFun.convertDurationToNamedGroup(test[0]))
-      end
-   end
+    tests.each do |test|
+      assert_equal(test[1], AdiwgDateTimeFun.convertDurationToNamedGroup(test[0]))
+    end
+  end
 end

--- a/test/internal/module_utils.rb
+++ b/test/internal/module_utils.rb
@@ -56,7 +56,9 @@ class TestDateTimeFun < Minitest::Test
       ['<foo gco:nilReason="withheld"></foo>', [true, 'withheld']],
       ['<foo gco:nilReason="unavailable"></foo>', [true, 'unavailable']],
       ['<foo gco:nilReason="other:ab"></foo>', [true, 'other:ab']],
-      ['<foo gco:nilReason="test:uri"></foo>', [true, 'test:uri']],
+      ['<foo gco:nilReason="https://john.doe@www.example.com:1234"></foo>',
+       [true, 'https://john.doe@www.example.com:1234']],
+      ['<foo indeterminatePosition="now"></foo>', [true, 'now']],
       ['<foo gco:nilReason="bad value"></foo>', [false, 'bad value']],
       ['<foo></foo>', [false, nil]]
     ]

--- a/test/internal/module_utils.rb
+++ b/test/internal/module_utils.rb
@@ -49,16 +49,16 @@ class TestDateTimeFun < Minitest::Test
 
   def test_nil_reason_checker
     tests = [
-      ['<foo gco:nilReason="inapplicable"></foo>', true],
-      ['<foo gco:nilReason="missing"></foo>', true],
-      ['<foo gco:nilReason="template"></foo>', true],
-      ['<foo gco:nilReason="unknown"></foo>', true],
-      ['<foo gco:nilReason="withheld"></foo>', true],
-      ['<foo gco:nilReason="unavailable"></foo>', true],
-      ['<foo gco:nilReason="other:ab"></foo>', true],
-      ['<foo gco:nilReason="test:uri"></foo>', true],
-      ['<foo gco:nilReason="bad value"></foo>', false],
-      ['<foo></foo>', false]
+      ['<foo gco:nilReason="inapplicable"></foo>', [true, 'inapplicable']],
+      ['<foo gco:nilReason="missing"></foo>', [true, 'missing']],
+      ['<foo gco:nilReason="template"></foo>', [true, 'template']],
+      ['<foo gco:nilReason="unknown"></foo>', [true, 'unknown']],
+      ['<foo gco:nilReason="withheld"></foo>', [true, 'withheld']],
+      ['<foo gco:nilReason="unavailable"></foo>', [true, 'unavailable']],
+      ['<foo gco:nilReason="other:ab"></foo>', [true, 'other:ab']],
+      ['<foo gco:nilReason="test:uri"></foo>', [true, 'test:uri']],
+      ['<foo gco:nilReason="bad value"></foo>', [false, 'bad value']],
+      ['<foo></foo>', [false, nil]]
     ]
 
     tests.each do |test|

--- a/test/readers/iso19115_2_datagov/tc_iso19115_2_date.rb
+++ b/test/readers/iso19115_2_datagov/tc_iso19115_2_date.rb
@@ -20,7 +20,7 @@ class TestReaderIso191152datagovDate < TestReaderIso191152datagovParent
     refute_empty hDictionary
     assert hDictionary.instance_of? Hash
     assert_equal(DateTime.iso8601('2017-01-01T00:00:00+00:00'), hDictionary[:date])
-    assert_equal('Y', hDictionary[:dateResolution])
+    assert_equal('YMDhms', hDictionary[:dateResolution])
     assert_equal('publication', hDictionary[:dateType])
   end
 

--- a/test/readers/iso19115_2_datagov/tc_iso19115_2_responsibility.rb
+++ b/test/readers/iso19115_2_datagov/tc_iso19115_2_responsibility.rb
@@ -45,21 +45,6 @@ class TestReaderIso191152datagovResponsibility < TestReaderIso191152datagovParen
     assert_equal(false, hResponse[:readerValidationPass])
   end
 
-  def test_responsibility_no_ind_or_org
-    xDoc = TestReaderIso191152datagovParent.get_xml('iso19115-2_rp_no_ind_or_org.xml')
-    TestReaderIso191152datagovParent.set_xdoc(xDoc)
-
-    xIn = xDoc.xpath('.//gmd:citedResponsibleParty')[0]
-    hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
-    _hDictionary = @@nameSpace.unpack(xIn, hResponse)
-
-    expected = "WARNING: ISO19115-2 reader: 'gmd:CI_ResponsibleParty' must have "\
-    'at least an individual or organization. neither are present.'
-
-    assert_equal([expected], hResponse[:readerValidationMessages])
-    assert_equal(false, hResponse[:readerValidationPass])
-  end
-
   def test_no_nil_reasons
     xDoc = TestReaderIso191152datagovParent.get_xml('iso19115-2_responsibility_nilreasons.xml')
     TestReaderIso191152datagovParent.set_xdoc(xDoc)

--- a/test/readers/iso19115_2_datagov/tc_iso19115_2_time_period.rb
+++ b/test/readers/iso19115_2_datagov/tc_iso19115_2_time_period.rb
@@ -80,7 +80,7 @@ class TestReaderIso191152datagovTimePeriod < TestReaderIso191152datagovParent
 
     infos = [
       "INFO: ISO19115-2 reader: element 'begin' contains acceptable nilReason: 'missing'",
-      "INFO: ISO19115-2 reader: element 'end' contains acceptable nilReason: 'missing'"
+      "INFO: ISO19115-2 reader: element 'end' contains acceptable nilReason: 'now'"
     ]
     assert_equal(infos, hResponse[:readerValidationMessages])
     assert_equal(true, hResponse[:readerValidationPass])

--- a/test/readers/iso19115_2_datagov/testData/iso19115-2.xml
+++ b/test/readers/iso19115_2_datagov/testData/iso19115-2.xml
@@ -77,7 +77,7 @@
             <gmd:date>
                <gmd:CI_Date>
                <gmd:date>
-                  <gco:Date>2017</gco:Date>
+                  <gco:DateTime>2017-01-01T00:00:00</gco:DateTime>
                </gmd:date>
                <gmd:dateType>
                   <gmd:CI_DateTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#CI_DateTypeCode" codeListValue="publication" codeSpace="002"/>
@@ -266,7 +266,7 @@
       <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>
           <gmd:keyword>
-            <gco:CharacterString>biota</gco:CharacterString>
+            <gmx:Anchor>biota</gmx:Anchor>
           </gmd:keyword>
           <gmd:keyword>
             <gco:CharacterString>farming</gco:CharacterString>

--- a/test/readers/iso19115_2_datagov/testData/iso19115-2_time_period_nilreasons.xml
+++ b/test/readers/iso19115_2_datagov/testData/iso19115-2_time_period_nilreasons.xml
@@ -38,7 +38,7 @@
               <gmd:extent>
                 <gml:TimePeriod gml:id="timePeriod_001">
                   <gml:begin gco:nilReason="missing" />
-                  <gml:end gco:nilReason="missing" />
+                  <gml:end indeterminatePosition="now" />
                 </gml:TimePeriod>
               </gmd:extent>
             </gmd:EX_TemporalExtent>


### PR DESCRIPTION
related to [#4924](https://github.com/GSA/data.gov/issues/4924)

- updated xpaths to handle multi-sibling elements including associated tests & fixtures
- removed logic to throw warning if individual and organization are missing ( i made this rule but it's not to spec ) 
- add missing tests and file to lint ( lint file )
