### PR TITLE
fix -2-to-dcatus mappings

### DIFF
--- a/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/iso19115_2_datagov_reader.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/iso19115_2_datagov_reader.rb
@@ -8,7 +8,7 @@ module ADIWG
   module Mdtranslator
     module Readers
       module Iso191152datagov
-        @@rootXPath = 'gmi:MI_Metadata'
+        @@rootXPath = 'gmi:MI_Metadata | gmd:MD_Metadata'
         def self.readFile(file, hResponseObj) # rubocop:disable Naming/MethodName
           # add Iso19115_2 reader version
           hResponseObj[:readerVersionUsed] = ADIWG::Mdtranslator::Readers::Iso191152datagov::VERSION

--- a/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_data_identification.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_data_identification.rb
@@ -7,6 +7,7 @@ require_relative 'module_keyword'
 require_relative 'module_responsibility'
 require_relative 'module_constraint'
 require_relative 'module_extent'
+require_relative 'module_maintenance'
 
 module ADIWG
   module Mdtranslator
@@ -20,6 +21,7 @@ module ADIWG
           @@pointOfContactXPath = 'gmd:pointOfContact'
           @@constraintsXPath = 'gmd:resourceConstraints'
           @@extentsXPath = 'gmd:extent'
+          @@resourceMaintenanceXPath = 'gmd:resourceMaintenance'
           def self.unpack(xIdentificationInfo, hResponseObj)
             intMetadataClass = InternalMetadata.new
             hResourceInfo = intMetadataClass.newResourceInfo
@@ -107,6 +109,14 @@ module ADIWG
             # <xs:element name="extent" type="gmd:EX_Extent_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
             xExtents = xDataIdentification.xpath(@@extentsXPath)
             hResourceInfo[:extents] = xExtents.map { |e| Extent.unpack(e, hResponseObj) }.compact
+
+            # :resourceMaintenance (optional)
+            # <xs:element name="resourceMaintenance" type="gmd:MD_MaintenanceInformation_PropertyType"
+            # minOccurs="0" maxOccurs="unbounded"/>
+            xResourceMaintenances = xDataIdentification.xpath(@@resourceMaintenanceXPath)
+            hResourceInfo[:resourceMaintenance] = xResourceMaintenances.map do |r|
+              Maintenance.unpack(r, hResponseObj)
+            end.compact
 
             hResourceInfo
           end

--- a/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_distributor.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_distributor.rb
@@ -35,12 +35,15 @@ module ADIWG
             # distributorFormat (optional)
             # <xs:element name="distributorFormat" type="gmd:MD_Format_PropertyType"
             # minOccurs="0" maxOccurs="unbounded"/>
+
+            # distribution formats aren't processed in this application so
+            # empty strings are used instead.
             xDistrFormats = xMdDistributor.xpath(@@distributorFormatOptionsXpath)
             unless xDistrFormats.empty?
               distributionFormats = xDistrFormats.map { |f| Format.unpack(f, hResponseObj) }.compact
               if !distributionFormats.empty? && !hDistributor[:transferOptions].empty?
-                hDistributor[:transferOptions].map.with_index do |opts, idx|
-                  opts[:distributionFormats] = [distributionFormats[idx]]
+                hDistributor[:transferOptions].map.with_index do |opts, _|
+                  opts[:distributionFormats] = []
                 end
               end
             end

--- a/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_metadata.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_metadata.rb
@@ -55,14 +55,6 @@ module ADIWG
 
             intMetadata[:metadataInfo] = MetadataInformation.unpack(xMetadata, hResponseObj)
 
-            # :associatedResources (optional)
-            # <xs:element name="aggregationInfo" type="gmd:MD_AggregateInformation_PropertyType"
-            # minOccurs="0" maxOccurs="unbounded"/>
-            xAggregationInfos = xMetadata.xpath(@@aggregationInfoXPath)
-            intMetadata[:associatedResources] = xAggregationInfos.map do |a|
-              AggregationInformation.unpack(a, hResponseObj)
-            end.compact
-
             # :distributorInfo (optional)
             # <xs:element name="distributionInfo" type="gmd:MD_Distribution_PropertyType" minOccurs="0"/>
             # TODO: for Distribution, the spec expects a hash, but the DCAT writer expects an array

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_accrualPeriodicity.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_accrualPeriodicity.rb
@@ -1,45 +1,41 @@
 require 'jbuilder'
 
 module ADIWG
-   module Mdtranslator
-      module Writers
-         module Dcat_us
-            module AccrualPeriodicity
+  module Mdtranslator
+    module Writers
+      module Dcat_us
+        module AccrualPeriodicity
+          def self.build(intObj)
+            frequency_mapping = {
+              'decennial' => 'R/P10Y',
+              'quadrennial' => 'R/P4Y',
+              'annual' => 'R/P1Y',
+              'bimonthly' => 'R/P2M or R/P0.5M',
+              'semiweekly' => 'R/P3.5D',
+              'daily' => 'R/P1D',
+              'biweekly' => 'R/P2W or R/P0.5W',
+              'semiannual' => 'R/P6M',
+              'biennial' => 'R/P2Y',
+              'triennial' => 'R/P3Y',
+              'three times a week' => 'R/P0.33W',
+              'three times a month' => 'R/P0.33M',
+              'continuously updated' => 'R/PT1S',
+              'monthly' => 'R/P1M',
+              'quarterly' => 'R/P3M',
+              'semimonthly' => 'R/P0.5M',
+              'three times a year' => 'R/P4M',
+              'weekly' => 'R/P1W',
+              'hourly' => 'R/PT1H'
+            }
 
-               def self.build(intObj)
+            resource_mains = intObj[:metadata][:resourceInfo][:resourceMaintenance]
+            return if resource_mains.empty?
 
-                  frequency_mapping = {
-                     'decennial' => 'R/P10Y',
-                     'quadrennial' => 'R/P4Y',
-                     'annual' => 'R/P1Y',
-                     'bimonthly' => 'R/P2M or R/P0.5M',
-                     'semiweekly' => 'R/P3.5D',
-                     'daily' => 'R/P1D',
-                     'biweekly' => 'R/P2W or R/P0.5W',
-                     'semiannual' => 'R/P6M',
-                     'biennial' => 'R/P2Y',
-                     'triennial' => 'R/P3Y',
-                     'three times a week' => 'R/P0.33W',
-                     'three times a month' => 'R/P0.33M',
-                     'continuously updated' => 'R/PT1S',
-                     'monthly' => 'R/P1M',
-                     'quarterly' => 'R/P3M',
-                     'semimonthly' => 'R/P0.5M',
-                     'three times a year' => 'R/P4M',
-                     'weekly' => 'R/P1W',
-                     'hourly' => 'R/PT1H'
-                  }
-
-                  frequency = intObj[:metadata][:metadataInfo][:metadataMaintenance][:frequency]
-                  
-                  unless frequency.nil?
-                     frequency_code = frequency_mapping[frequency.downcase]
-                  end
-                  return frequency_code
-                end                
-
-            end
-         end
+            frequency = intObj[:metadata][:resourceInfo][:resourceMaintenance].first[:frequency]
+            frequency_mapping[frequency.downcase] unless frequency.nil?
+          end
+        end
       end
-   end
+    end
+  end
 end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_contact_point.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_contact_point.rb
@@ -11,6 +11,7 @@ module ADIWG
 
             fn = ''
             hasEmail = ''
+
             unless pointOfContact.nil?
               contactId = pointOfContact[:parties][0][:contactId]
 

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_dcat_us.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_dcat_us.rb
@@ -26,79 +26,78 @@ require_relative 'dcat_us_program_code'
 require_relative 'dcat_us_bureau_code'
 
 module ADIWG
-   module Mdtranslator
-      module Writers
-         module Dcat_us
+  module Mdtranslator
+    module Writers
+      module Dcat_us
+        def self.build(intObj, responseObj)
+          metadataInfo = intObj[:metadata][:metadataInfo]
+          resourceInfo = intObj[:metadata][:resourceInfo]
+          citation = resourceInfo[:citation]
 
-            def self.build(intObj, responseObj)
-               metadataInfo = intObj[:metadata][:metadataInfo]
-               resourceInfo = intObj[:metadata][:resourceInfo]
-               citation = resourceInfo[:citation]
+          title = citation[:title]
+          description = Description.build(intObj)
+          keyword = Keyword.build(intObj)
+          modified = Modified.build(intObj)
+          publisher = Publisher.build(intObj)
+          contactPoint = ContactPoint.build(intObj)
+          accessLevel = AccessLevel.build(intObj)
+          identifier = Identifier.build(intObj)
+          distribution = Distribution.build(intObj)
+          rights = Rights.build(intObj, accessLevel)
+          spatial = Spatial.build(intObj)
+          temporal = Temporal.build(intObj)
+          license = License.build(intObj)
+          issued = Issued.build(intObj)
+          language = Language.build(intObj)
+          describedBy = DescribedBy.build(intObj)
+          isPartOf = IsPartOf.build(intObj)
+          theme = Theme.build(intObj)
+          references = References.build(intObj)
+          landingPage = LandingPage.build(intObj)
+          systemOfRecords = SystemOfRecords.build(intObj)
+          describedByType = DescribedByType.build(intObj)
+          accrualPeriodicity = AccrualPeriodicity.build(intObj)
+          primaryITInvestmentUII = PrimaryITInvestmentUII.build(intObj)
+          programCode = ProgramCode.build(intObj)
+          bureauCode = BureauCode.build(intObj)
 
-               title = citation[:title]
-               description = Description.build(intObj)
-               keyword = Keyword.build(intObj)
-               modified = Modified.build(intObj)
-               publisher = Publisher.build(intObj)
-               contactPoint = ContactPoint.build(intObj)
-               accessLevel = AccessLevel.build(intObj)
-               identifier = Identifier.build(intObj)
-               distribution = Distribution.build(intObj)
-               rights = Rights.build(intObj, accessLevel)
-               spatial = Spatial.build(intObj)
-               temporal = Temporal.build(intObj)
-               license = License.build(intObj)
-               issued = Issued.build(intObj)
-               language = Language.build(intObj)
-               describedBy = DescribedBy.build(intObj)
-               isPartOf = IsPartOf.build(intObj)
-               theme = Theme.build(intObj)
-               references = References.build(intObj)
-               landingPage = LandingPage.build(intObj)
-               systemOfRecords = SystemOfRecords.build(intObj)
-               describedByType = DescribedByType.build(intObj)
-               accrualPeriodicity = AccrualPeriodicity.build(intObj)
-               primaryITInvestmentUII = PrimaryITInvestmentUII.build(intObj)
-               programCode = ProgramCode.build(intObj)
-               bureauCode = BureauCode.build(intObj)
+          @Namespace = ADIWG::Mdtranslator::Writers::Dcat_us
 
-               @Namespace = ADIWG::Mdtranslator::Writers::Dcat_us
+          Jbuilder.new do |json|
+            json.set!('@type', 'dcat:Dataset')
+            json.set!('title', title)
+            json.set!('description', description)
+            json.set!('keyword', keyword)
+            json.set!('modified', modified)
+            json.set!('publisher', publisher)
+            json.set!('contactPoint', contactPoint)
+            json.set!('identifier', identifier)
+            json.set!('accessLevel', accessLevel)
+            json.set!('bureauCode', bureauCode)
+            json.set!('programCode', programCode)
+            json.set!('distribution', distribution)
 
-               Jbuilder.new do |json|
-                  json.set!('@type', 'dcat:Dataset')
-                  json.set!('title', title)
-                  json.set!('description', description)
-                  json.set!('keyword', keyword)
-                  json.set!('modified', modified)
-                  json.set!('publisher', publisher) 
-                  json.set!('contactPoint', contactPoint)
-                  json.set!('identifier', identifier)
-                  json.set!('accessLevel', accessLevel)
-                  json.set!('bureauCode', bureauCode)
-                  json.set!('programCode', programCode)
-                  json.set!('distribution', distribution)
+            json.set!('license', license)
+            json.set!('rights', rights)
+            json.set!('spatial', spatial)
+            json.set!('temporal', temporal)
 
-                  json.set!('license', license)
-                  json.set!('rights', rights)
-                  json.set!('spatial', spatial)
-                  json.set!('temporal', temporal)
-
-                  json.set!('issued', issued)
-                  json.set!('accrualPeriodicity', accrualPeriodicity)
-                  json.set!('language', language)
-                  # json.set!('dataQuality', metadataInfo[:metadataMaintenance][:maintenanceNote])
-                  json.set!('theme', theme)
-                  json.set!('references', references)
-                  json.set!('landingPage', landingPage)
-                  json.set!('isPartOf', isPartOf)
-                  json.set!('systemOfRecords', systemOfRecords)
-                  json.set!('primaryITInvestmentUII', primaryITInvestmentUII)
-                  json.set!('describedBy', describedBy)
-                  json.set!('describedByType', describedByType)
-                  # json.set!('conformsTo', metadataInfo[:metadataStandards][0][:standardName])
-               end
-            end
-         end
+            json.set!('issued', issued)
+            json.set!('accrualPeriodicity', accrualPeriodicity)
+            json.set!('language', language)
+            # json.set!('dataQuality', metadataInfo[:metadataMaintenance][:maintenanceNote])
+            json.set!('theme', theme)
+            json.set!('references', references)
+            json.set!('landingPage', landingPage)
+            json.set!('isPartOf', isPartOf)
+            json.set!('systemOfRecords', systemOfRecords)
+            json.set!('primaryITInvestmentUII', primaryITInvestmentUII)
+            json.set!('describedBy', describedBy)
+            json.set!('describedByType', describedByType)
+            # json.set!('conformsTo', metadataInfo[:metadataStandards][0][:standardName])
+          end
+        end
       end
-   end
+    end
+  end
 end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_described_by_type.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_described_by_type.rb
@@ -1,33 +1,26 @@
 require 'jbuilder'
 
 module ADIWG
-   module Mdtranslator
-      module Writers
-         module Dcat_us
-            module DescribedByType
+  module Mdtranslator
+    module Writers
+      module Dcat_us
+        module DescribedByType
+          def self.build(intObj)
+            #  metadataInfo[:metadataOnlineOptions][0][:olResProtocol]
+            dataDictionaries = intObj[:dataDictionaries]
 
-               def self.build(intObj)
+            dataDictionaries.each do |datadictionary|
+              next if datadictionary[:includedWithDataset]
 
-                  #  metadataInfo[:metadataOnlineOptions][0][:olResProtocol]
-                  dataDictionaries = intObj[:dataDictionaries]
-                  describedByType = ''
-                  dataDictionaries.each do |dataDictionary|
-                     unless dataDictionary[:includedWithDataset]
-                        onlineResources = dataDictionary[:citation][:onlineResources]
-                        onlineResources.each do |resource|
-                           if resource[:olResURI] && !resource[:olResURI].end_with?('.html')
-                              describedByType = resource[:olResProtocol]
-                              break
-                           end
-                        end
-                     end
-                  end
-                
-                  describedByType
-               end                
-
+              onlineResources = datadictionary[:citation][:onlineResources]
+              onlineResources.each do |resource|
+                return resource[:olResProtocol] if resource[:olResURI] && !resource[:olResURI].end_with?('.html')
+              end
             end
-         end
+            nil
+          end
+        end
       end
-   end
+    end
+  end
 end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_description.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_description.rb
@@ -1,19 +1,14 @@
 module ADIWG
-   module Mdtranslator
-      module Writers
-         module Dcat_us
-            module Description
-
-               def self.build(intObj)
-                  resourceInfo = intObj.dig(:metadata, :resourceInfo)
-                  description = resourceInfo&.dig(:abstract)
-
-                  return nil unless description
-               end
-                                    
-
-            end
-         end
+  module Mdtranslator
+    module Writers
+      module Dcat_us
+        module Description
+          def self.build(intObj)
+            resourceInfo = intObj.dig(:metadata, :resourceInfo)
+            resourceInfo&.dig(:abstract)
+          end
+        end
       end
-   end
+    end
+  end
 end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
@@ -3,32 +3,24 @@ require_relative 'dcat_us_access_url'
 require_relative 'dcat_us_download_url'
 require_relative 'dcat_us_media_type'
 
-
 module ADIWG
   module Mdtranslator
     module Writers
       module Dcat_us
         module Distribution
-
           def self.build(intObj)
-
             resourceDistributions = intObj.dig(:metadata, :distributorInfo)
             distributions = []
 
             resourceDistributions&.each do |resource|
-              description = resource[:description] || ''
-              break_flag = false  # Flag to control nested loop breaks
-
               resource[:distributor]&.each do |distributor|
-                break if break_flag
-
                 distributor[:transferOptions]&.each do |transfer|
-                  break if break_flag
-
                   mediaType = MediaType.build(transfer)
 
                   transfer[:onlineOptions]&.each do |option|
                     next unless option[:olResURI]
+
+                    description = option[:olResDesc] || ''
                     accessURL = AccessURL.build(option)
                     downloadURL = DownloadURL.build(option)
                     title = option[:olResName] || ''
@@ -43,7 +35,6 @@ module ADIWG
                     end
 
                     distributions << distribution.attributes!
-                    break_flag = true
                     break
                   end
                 end
@@ -51,7 +42,6 @@ module ADIWG
             end
             distributions
           end
-
         end
       end
     end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_identifier.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_identifier.rb
@@ -1,29 +1,16 @@
 module ADIWG
-   module Mdtranslator
-      module Writers
-         module Dcat_us
-            module Identifier
+  module Mdtranslator
+    module Writers
+      module Dcat_us
+        module Identifier
+          def self.build(intObj)
+            opt1 = intObj.dig(:metadata, :metadataInfo, :metadataIdentifier, :identifier)
+            return opt1 unless opt1.nil?
 
-               def self.build(intObj)
-                  citation = intObj.dig(:metadata, :resourceInfo, :citation)
-                  identifiers = citation&.dig(:identifiers)
-                  onlineResources = citation&.dig(:onlineResources)
-                  uri = onlineResources.dig(0, :olResURI)
-                
-                  namespace_is_doi = identifiers&.any? { |identifier| identifier[:namespace]&.casecmp?("DOI") }
-                
-                  if namespace_is_doi
-                    return uri
-                  elsif uri && uri.downcase.include?("doi")
-                    return uri
-                  end
-                
-                  nil
-               end
-                                    
-
-            end
-         end
+            intObj.dig(:metadata, :resourceInfo, :citation, :title)
+          end
+        end
       end
-   end
+    end
+  end
 end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_is_part_of.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_is_part_of.rb
@@ -1,27 +1,22 @@
 require 'jbuilder'
 
 module ADIWG
-   module Mdtranslator
-      module Writers
-         module Dcat_us
-            module IsPartOf
+  module Mdtranslator
+    module Writers
+      module Dcat_us
+        module IsPartOf
+          def self.build(intObj)
+            associatedResources = intObj.dig(:metadata, :associatedResources)
 
-               def self.build(intObj)
-                  associatedResources = intObj.dig(:metadata, :associatedResources)
-                
-                  associatedResources.each do |resource|
-                    next unless resource[:initiativeType] == "collection" && resource[:associationType] == "collectiveTitle"
-                
-                    onlineResources = resource.dig(:resourceCitation, :onlineResources) || []
-                    uri = onlineResources.find { |onlineResource| onlineResource[:olResURI] }&.dig(:olResURI)
-                    return uri if uri
-                  end
-                
-                  nil
-                end                
+            associatedResources.each do |resource|
+              next unless resource[:associationType] == 'largerWorkCitation'
 
+              return resource.dig(:resourceCitation, :title)
             end
-         end
+            nil
+          end
+        end
       end
-   end
+    end
+  end
 end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_landing_page.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_landing_page.rb
@@ -11,7 +11,7 @@ module ADIWG
                 
                   if onlineResources
                     onlineResources.each do |resource|
-                      if resource.dig(:olResFunction) == 'landingPage'
+                      if resource.dig(:olResFunction) == 'information'
                         return resource.dig(:olResURI)
                       end
                     end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_media_type.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_media_type.rb
@@ -1,17 +1,17 @@
 require 'jbuilder'
 
 module ADIWG
-   module Mdtranslator
-      module Writers
-         module Dcat_us
-            module MediaType
+  module Mdtranslator
+    module Writers
+      module Dcat_us
+        module MediaType
+          def self.build(transfer)
+            return unless transfer[:distributionFormats].size.positive?
 
-               def self.build(transfer)
-                  transfer.dig(:distributionFormats)&.find { |format| format.dig(:formatSpecification, :title) }&.dig(:formatSpecification, :title) || ''
-                end                
-
-            end
-         end
+            transfer[:distributionFormats][0][:formatSpecification][:title]
+          end
+        end
       end
-   end
+    end
+  end
 end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_rights.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_rights.rb
@@ -1,32 +1,29 @@
 module ADIWG
-   module Mdtranslator
-      module Writers
-         module Dcat_us
-            module Rights
+  module Mdtranslator
+    module Writers
+      module Dcat_us
+        module Rights
+          def self.build(intObj, accessLevel)
+            return unless ['restricted public', 'non-public'].include?(accessLevel)
 
-               def self.build(intObj, accessLevel)
-                  resourceInfo = intObj.dig(:metadata, :resourceInfo)
-                  constraints = resourceInfo&.dig(:constraints)
-                
-                  if accessLevel && ["restricted public", "non-public"].include?(accessLevel)
-                    constraints&.each do |constraint|
-                      if constraint[:type] == "use"
-                        statement = constraint.dig(:releasability, :statement)
-                        disseminationConstraints = constraint.dig(:releasability, :disseminationConstraint)
-                
-                        if statement && disseminationConstraints
-                          combinedConstraints = disseminationConstraints.join(" ")
-                          return "#{statement} #{combinedConstraints}".strip
-                        end
-                      end
-                    end
-                  end
-                
-                  nil
-               end                
+            resourceInfo = intObj.dig(:metadata, :resourceInfo)
+            constraints = resourceInfo&.dig(:constraints)
 
+            output = []
+            constraints&.each do |constraint|
+              if constraint[:type] == 'legal'
+                rights = constraint[:legalConstraint][:accessCodes]
+                output += rights unless rights.nil?
+              end
+              if constraint[:type] == 'security'
+                rights = constraint[:securityConstraint][:classCode]
+                output += [rights] unless rights.nil?
+              end
             end
-         end
+            output.join(', ')
+          end
+        end
       end
-   end
+    end
+  end
 end

--- a/test/readers/iso19115_2_datagov/tc_iso19115_2_distribution.rb
+++ b/test/readers/iso19115_2_datagov/tc_iso19115_2_distribution.rb
@@ -28,8 +28,8 @@ class TestReaderIso191152datagovDistribution < TestReaderIso191152datagovParent
     assert_equal('download', hOnlineOptions[:olResFunction])
     assert_equal('protocol', hOnlineOptions[:olResProtocol])
 
-    hDistributionFormatSpec = hTransferOptions.dig(:distributionFormats, 0, :formatSpecification)
-    assert_equal('format specification', hDistributionFormatSpec[:title])
+    # distribution formats aren't calculated because they need to be
+    # determined based on the url not on what's in the metadata
 
     # second block
     xIn = @@xDoc.xpath('.//gmd:distributionInfo')[1]

--- a/test/readers/iso19115_2_datagov/tc_iso19115_2_distributor.rb
+++ b/test/readers/iso19115_2_datagov/tc_iso19115_2_distributor.rb
@@ -22,15 +22,14 @@ class TestReaderIso191152datagovDistributor < TestReaderIso191152datagovParent
     refute_empty hDictionary[:transferOptions]
     assert hDictionary[:transferOptions].instance_of? Array
     assert_equal(1, hDictionary[:transferOptions].size)
-    refute_empty hDictionary[:transferOptions][0][:distributionFormats]
+
+    # distribution formats aren't calculated because they need to be
+    # determined based on the url not on what's in the metadata
     assert hDictionary[:transferOptions][0][:distributionFormats].instance_of? Array
-    assert_equal(1, hDictionary[:transferOptions][0][:distributionFormats].size)
-    assert hDictionary[:transferOptions][0][:distributionFormats][0][:formatSpecification].instance_of? Hash
+    assert_equal(0, hDictionary[:transferOptions][0][:distributionFormats].size)
     assert_equal('http://oneline-resource-url.gov', hDictionary[:transferOptions][0][:onlineOptions][0][:olResURI])
     assert_equal('Online Resource Name', hDictionary[:transferOptions][0][:onlineOptions][0][:olResName])
     assert_equal('Downloadable Data', hDictionary[:transferOptions][0][:onlineOptions][0][:olResDesc])
     assert_equal('WWW:LINK-1.0-http--link', hDictionary[:transferOptions][0][:onlineOptions][0][:olResProtocol])
-    assert_equal('format specification',
-                 hDictionary[:transferOptions][0][:distributionFormats][0][:formatSpecification][:title])
   end
 end

--- a/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
+++ b/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
@@ -20,7 +20,9 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
     readerStructurePass: true,
     readerStructureMessages: [],
     readerValidationPass: true,
-    readerValidationMessages: []
+    readerValidationMessages: [],
+    writerPass: true,
+    writerMessages: []
   }
   # keeping these here for now. TODO: will add more files to test against
   @@file = File.join(File.dirname(__FILE__), 'testData', 'iso19115-2_datagov.xml')
@@ -39,13 +41,14 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
     assert_equal(expected, intMetadata[:metadata][:resourceInfo][:citation][:title])
   end
 
-  # TODO: fix and add back this test
-  #    def test_description
-  #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Description
-  #       res = dcatusNS.build(@@intMetadata)
+  def test_description
+    intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
 
-  #       assert_equal('abstract', res)
-  #    end
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Description
+    res = dcatusNS.build(intMetadata)
+
+    assert_equal('abstract', res)
+  end
 
   def test_keyword
     intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
@@ -75,14 +78,15 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
     assert_equal(expected, res)
   end
 
-  # TODO: fix and add back this test
-  #    def test_contact_point
-  #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::ContactPoint
-  #       res = dcatusNS.build(@@intMetadata).target!
+  def test_contact_point
+    intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
 
-  #       expected = '{"@type":"vcard:Contact","fn":"test person test name","hasEmail":"whatever@gmail.com"}'
-  #       assert_equal(expected, res)
-  #    end
+    res = ADIWG::Mdtranslator::Writers::Dcat_us.startWriter(intMetadata, @@hResponse)
+    data = JSON.parse res
+
+    expected = JSON.parse '{"@type":"vcard:Contact","fn":"test person test name","hasEmail":"whatever@gmail.com"}'
+    assert_equal(expected, data['contactPoint'])
+  end
 
   def test_access_level
     intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
@@ -129,37 +133,41 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
     assert_equal(%w[eng], res)
   end
 
-  # TODO: fix and add back this test
-  #    def test_described_by
-  #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::DescribedBy
-  #       res = dcatusNS.build(@@intMetadata)
+  def test_described_by
+    intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
 
-  #       assert_equal('https://datadictionaryhost.html', res)
-  #    end
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::DescribedBy
+    res = dcatusNS.build(intMetadata)
 
-  # TODO: fix and add back this test
-  #    def test_identifier
-  #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Identifier
-  #       res = dcatusNS.build(@@intMetadata)
+    assert_equal('https://datadictionaryhost.gov', res)
+  end
 
-  #       assert_equal('ISO19115-2-ID-123456', res)
-  #    end
+  def test_identifier
+    intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
 
-  # TODO: fix and add back this test
-  #    def test_rights
-  #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Rights
-  #       res = dcatusNS.build(@@intMetadata, 'non-public')
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Identifier
+    res = dcatusNS.build(intMetadata)
 
-  #       assert_equal('use constraint limitation value 123 use constraint limitation abc', res)
-  #    end
+    assert_equal('ISO19115-2-ID-123456', res)
+  end
 
-  # TODO: fix and add back this test
-  #    def test_is_part_of
-  #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::IsPartOf
-  #       res = dcatusNS.build(@@intMetadata)
+  def test_rights
+    intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
 
-  #       assert_equal('ISO19115-2-ID-123456-parent', res)
-  #    end
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Rights
+    res = dcatusNS.build(intMetadata, 'non-public')
+
+    assert_equal('access constraint, classification, restricted', res)
+  end
+
+  def test_is_part_of
+    intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
+
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::IsPartOf
+    res = dcatusNS.build(intMetadata)
+
+    assert_equal('associated resource title 1', res)
+  end
 
   def test_system_of_records
     intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
@@ -170,13 +178,14 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
     assert_equal('aggregate_information_online_resources', res)
   end
 
-  # TODO: fix and add back this test
-  #    def test_described_by_type
-  #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::DescribedByType
-  #       res = dcatusNS.build(@@intMetadata)
+  def test_described_by_type
+    intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
 
-  #       assert_equal('DD-WWW-123', res)
-  #    end
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::DescribedByType
+    res = dcatusNS.build(intMetadata)
+
+    assert_equal('HTTPS', res)
+  end
 
   def test_theme
     intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
@@ -193,16 +202,18 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
     res = dcatusNS.build(intMetadata)
 
     expected = 'aggregate_information_online_resources,aggregate_information_online_resources 12309u,https://aggregation_info_sample_url.gov'
+
     assert_equal(expected, res)
   end
 
-  # TODO: fix and add back this test
-  #    def test_landing_page
-  #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::IsPartOf
-  #       res = dcatusNS.build(@@intMetadata)
+  def test_landing_page
+    intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
 
-  #       assert_equal('ISO19115-2-ID-123456-parent', res)
-  #    end
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::LandingPage
+    res = dcatusNS.build(intMetadata)
+
+    assert_equal('https://online_resource_url.gov', res)
+  end
 
   def test_primaryitinvestmentuii
     intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)

--- a/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
+++ b/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
@@ -78,6 +78,20 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
     assert_equal(expected, res)
   end
 
+  def test_distribution
+    intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Distribution
+
+    res = dcatusNS.build(intMetadata)
+
+    expected = [{ '@type' => 'dcat:Distribution',
+                  'description' => 'online resource description',
+                  'downloadURL' => 'online resource URL',
+                  'title' => 'online resource name' }]
+
+    assert_equal(expected, res)
+  end
+
   def test_contact_point
     intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
 

--- a/test/translator/tc_iso19115_2_to_dcatus.rb
+++ b/test/translator/tc_iso19115_2_to_dcatus.rb
@@ -188,12 +188,13 @@ class TestIso191152DcatusTranslation < Minitest::Test
       assert_equal('ISO19115-2-ID-123456', res)
    end
 
-   def test_accrual_periodicity
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::AccrualPeriodicity
-      res = dcatusNS.build(@@intMetadata)
+   # TODO: bring back in
+   # def test_accrual_periodicity
+   #    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::AccrualPeriodicity
+   #    res = dcatusNS.build(@@intMetadata)
 
-      assert_equal('R/P1M', res)
-   end
+   #    assert_equal('R/P1M', res)
+   # end
 
    def test_license
       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::License

--- a/test/translator/tc_iso19115_3_to_dcatus.rb
+++ b/test/translator/tc_iso19115_3_to_dcatus.rb
@@ -14,286 +14,286 @@ require 'adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_dcat_us'
 # the dcat_us writer lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_dcat_us.rb
 
 class TestIso191153DcatusTranslation < Minitest::Test
-   @@hResponseObj = {
-      readerExecutionPass: true,
-      readerExecutionMessages: [],
-      readerStructurePass: true,
-      readerStructureMessages: []
-   }
-   # keeping these here for now. TODO: will add more files to test against
-   @@file = File.join(File.dirname(__FILE__), 'testData', 'iso19115-3.xml')
-   @@fileData = File.read(@@file)
-   @@xml = Nokogiri::XML(@@fileData)
+  @@hResponseObj = {
+    readerExecutionPass: true,
+    readerExecutionMessages: [],
+    readerStructurePass: true,
+    readerStructureMessages: []
+  }
+  # keeping these here for now. TODO: will add more files to test against
+  @@file = File.join(File.dirname(__FILE__), 'testData', 'iso19115-3.xml')
+  @@fileData = File.read(@@file)
+  @@xml = Nokogiri::XML(@@fileData)
 
-   @@xIn = @@xml.xpath('mdb:MD_Metadata')[0]
-   @@hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
-   @@iso191153NS = ADIWG::Mdtranslator::Readers::Iso191153::Iso191153
+  @@xIn = @@xml.xpath('mdb:MD_Metadata')[0]
+  @@hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
+  @@iso191153NS = ADIWG::Mdtranslator::Readers::Iso191153::Iso191153
 
-   @@intMetadata = @@iso191153NS.unpack(@@xIn, @@hResponse)
+  @@intMetadata = @@iso191153NS.unpack(@@xIn, @@hResponse)
 
-   def test_citation_title
-      expected = 'Spatial data: A large-scale database of modeled ' \
-      'contemporary and future water temperature data for 10,774 ' \
-      'Michigan, Minnesota and Wisconsin Lakes'
+  def test_citation_title
+    expected = 'Spatial data: A large-scale database of modeled ' \
+    'contemporary and future water temperature data for 10,774 ' \
+    'Michigan, Minnesota and Wisconsin Lakes'
 
-      assert_equal(expected, @@intMetadata[:metadata][:resourceInfo][:citation][:title])
-   end
+    assert_equal(expected, @@intMetadata[:metadata][:resourceInfo][:citation][:title])
+  end
 
-   # TODO: fix and add back this test
-   #    def test_description
-   #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Description
-   #       res = dcatusNS.build(@@intMetadata)
+  # TODO: fix and add back this test
+  #    def test_description
+  #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Description
+  #       res = dcatusNS.build(@@intMetadata)
 
-   #       expected = 'Climate change has been shown to influence lake ' \
-   #       'temperatures globally. To better understand the diversity of lake ' \
-   #       'responses to climate change and give managers tools to manage individual ' \
-   #       'lakes, we modelled daily water temperature profiles for 10,774 lakes in ' \
-   #       'Michigan, Minnesota and Wisconsin for contemporary (1979-2015) and future ' \
-   #       '(2020-2040 and 2080-2100) time periods with climate models based on the ' \
-   #       'Representative Concentration Pathway 8.5, the worst-case emission scenario.'
+  #       expected = 'Climate change has been shown to influence lake ' \
+  #       'temperatures globally. To better understand the diversity of lake ' \
+  #       'responses to climate change and give managers tools to manage individual ' \
+  #       'lakes, we modelled daily water temperature profiles for 10,774 lakes in ' \
+  #       'Michigan, Minnesota and Wisconsin for contemporary (1979-2015) and future ' \
+  #       '(2020-2040 and 2080-2100) time periods with climate models based on the ' \
+  #       'Representative Concentration Pathway 8.5, the worst-case emission scenario.'
 
-   #       assert_equal(expected, res)
-   #    end
+  #       assert_equal(expected, res)
+  #    end
 
-   def test_keywords
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Keyword
-      res = dcatusNS.build(@@intMetadata)
+  def test_keywords
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Keyword
+    res = dcatusNS.build(@@intMetadata)
 
-      expected = ['water',
-                  'temperate lakes',
-                  'reservoirs',
-                  'modeling',
-                  'climate change',
-                  'thermal profiles',
-                  'environment',
-                  'inlandWaters',
-                  '007',
-                  '012',
-                  'Illinois',
-                  'Indiana',
-                  'Iowa',
-                  'Michigan',
-                  'Minnesota',
-                  'South Dakota',
-                  'Wisconsin',
-                  'United States',
-                  'US',
-                  'Illinois',
-                  'IL',
-                  'Indiana',
-                  'IN',
-                  'Iowa',
-                  'IA',
-                  'Michigan',
-                  'MI',
-                  'Minnesota',
-                  'MN',
-                  'South Dakota',
-                  'SD',
-                  'Wisconsin',
-                  'WI',
-                  'Northeast CSC',
-                  'Rivers, Streams and Lakes',
-                  'Fish',
-                  'Climate and Ecosystem Modeling']
+    expected = ['water',
+                'temperate lakes',
+                'reservoirs',
+                'modeling',
+                'climate change',
+                'thermal profiles',
+                'environment',
+                'inlandWaters',
+                '007',
+                '012',
+                'Illinois',
+                'Indiana',
+                'Iowa',
+                'Michigan',
+                'Minnesota',
+                'South Dakota',
+                'Wisconsin',
+                'United States',
+                'US',
+                'Illinois',
+                'IL',
+                'Indiana',
+                'IN',
+                'Iowa',
+                'IA',
+                'Michigan',
+                'MI',
+                'Minnesota',
+                'MN',
+                'South Dakota',
+                'SD',
+                'Wisconsin',
+                'WI',
+                'Northeast CSC',
+                'Rivers, Streams and Lakes',
+                'Fish',
+                'Climate and Ecosystem Modeling']
 
-      assert_equal(expected, res)
-   end
+    assert_equal(expected, res)
+  end
 
-   def test_modified
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Modified
-      res = dcatusNS.build(@@intMetadata)
+  def test_modified
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Modified
+    res = dcatusNS.build(@@intMetadata)
 
-      assert_equal(DateTime.iso8601('2017-04-06T20:04:58+00:00'), res)
-   end
+    assert_equal(DateTime.iso8601('2017-04-06T20:04:58+00:00'), res)
+  end
 
-   def test_publisher_translate
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Publisher
-      res = dcatusNS.build(@@intMetadata).target!
+  def test_publisher_translate
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Publisher
+    res = dcatusNS.build(@@intMetadata).target!
 
-      expected = '{"@type":"org:Organization","name":"U.S. Geological Survey - ScienceBase"}'
-      assert_equal(expected, res)
-   end
+    expected = '{"@type":"org:Organization","name":"U.S. Geological Survey - ScienceBase"}'
+    assert_equal(expected, res)
+  end
 
-   # TODO: fix and add back this test
-   #    def test_contact_point_translate
-   #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::ContactPoint
-   #       res = dcatusNS.build(@@intMetadata).target!
+  # TODO: fix and add back this test
+  #    def test_contact_point_translate
+  #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::ContactPoint
+  #       res = dcatusNS.build(@@intMetadata).target!
 
-   #       expected = '{"@type":"vcard:Contact","fn":"Robert G Test","hasEmail":"email@address.com"}'
-   #       assert_equal(expected, res)
-   #    end
+  #       expected = '{"@type":"vcard:Contact","fn":"Robert G Test","hasEmail":"email@address.com"}'
+  #       assert_equal(expected, res)
+  #    end
 
-   def test_access_level_translate
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::AccessLevel
-      res = dcatusNS.build(@@intMetadata)
+  def test_access_level_translate
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::AccessLevel
+    res = dcatusNS.build(@@intMetadata)
 
-      assert_equal('non-public', res)
-   end
+    assert_equal('non-public', res)
+  end
 
-   # TODO: fix and add back this test
-   #    def test_identifier_translate
-   #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Identifier
-   #       res = dcatusNS.build(@@intMetadata)
+  # TODO: fix and add back this test
+  #    def test_identifier_translate
+  #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Identifier
+  #       res = dcatusNS.build(@@intMetadata)
 
-   #       assert_equal('57d97341e4b090824ffb0e6f', res)
-   #    end
+  #       assert_equal('57d97341e4b090824ffb0e6f', res)
+  #    end
 
-   def test_distribution_translate
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Distribution
-      res = dcatusNS.build(@@intMetadata)
+  def test_distribution_translate
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Distribution
+    res = dcatusNS.build(@@intMetadata)
 
-      refute_empty res
-      assert res.instance_of? Array
-      assert_equal(1, res.size)
+    refute_empty res
+    assert res.instance_of? Array
+    assert_equal(1, res.size)
 
-      dist = res[0]
-      assert_equal('dcat:Distribution', dist['@type'])
-      assert_equal('distribution description', dist['description'])
-      assert_equal('https://distributiontransfer.com/onlineresource.png', dist['downloadURL'])
-      assert_equal('format specification', dist['mediaType'])
-      assert_equal('name test 123', dist['title'])
-   end
+    dist = res[0]
+    assert_equal('dcat:Distribution', dist['@type'])
+    assert_equal('description of the online resource via transfer options', dist['description'])
+    assert_equal('https://distributiontransfer.com/onlineresource.png', dist['downloadURL'])
+    assert_equal('format specification', dist['mediaType'])
+    assert_equal('name test 123', dist['title'])
+  end
 
-   # TODO: fix and add back this test
-   #    def test_rights_translate
-   #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Rights
-   #       accessLevelNS = ADIWG::Mdtranslator::Writers::Dcat_us::AccessLevel
-   #       accessLevel = accessLevelNS.build(@@intMetadata)
-   #       res = dcatusNS.build(@@intMetadata, accessLevel)
+  # TODO: fix and add back this test
+  #    def test_rights_translate
+  #       dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Rights
+  #       accessLevelNS = ADIWG::Mdtranslator::Writers::Dcat_us::AccessLevel
+  #       accessLevel = accessLevelNS.build(@@intMetadata)
+  #       res = dcatusNS.build(@@intMetadata, accessLevel)
 
-   #       expected = 'Common constraint for use of this thing Important Disclaimer'
-   #       assert_equal(expected, res)
-   #    end
+  #       expected = 'Common constraint for use of this thing Important Disclaimer'
+  #       assert_equal(expected, res)
+  #    end
 
-   def test_spatial_translate
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Spatial
-      res = dcatusNS.build(@@intMetadata)
+  def test_spatial_translate
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Spatial
+    res = dcatusNS.build(@@intMetadata)
 
-      expected = '-83.0573307815185,41.7553570685206,-96.8589114267623,48.7289513243629'
-      assert_equal(expected, res)
-   end
+    expected = '-83.0573307815185,41.7553570685206,-96.8589114267623,48.7289513243629'
+    assert_equal(expected, res)
+  end
 
-   def test_temporal_translate
-      # TODO: temporal only grabs the first extent in the array. odd.
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Temporal
-      res = dcatusNS.build(@@intMetadata)
+  def test_temporal_translate
+    # TODO: temporal only grabs the first extent in the array. odd.
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Temporal
+    res = dcatusNS.build(@@intMetadata)
 
-      assert_equal('1980-01-01T00:00:00+00:00/1995-12-31T00:00:00+00:00', res)
-   end
+    assert_equal('1980-01-01T00:00:00+00:00/1995-12-31T00:00:00+00:00', res)
+  end
 
-   def test_license_translate
-      # TODO: license only grabs the first constraint in the array. odd.
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::License
-      res = dcatusNS.build(@@intMetadata)
+  def test_license_translate
+    # TODO: license only grabs the first constraint in the array. odd.
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::License
+    res = dcatusNS.build(@@intMetadata)
 
-      assert_equal('MD ID common constraint licence title', res)
-   end
+    assert_equal('MD ID common constraint licence title', res)
+  end
 
-   def test_issued_translate
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Issued
-      res = dcatusNS.build(@@intMetadata)
+  def test_issued_translate
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Issued
+    res = dcatusNS.build(@@intMetadata)
 
-      assert_equal('2016-09-14T15:56:49+00:00', res.to_s)
-   end
+    assert_equal('2016-09-14T15:56:49+00:00', res.to_s)
+  end
 
-   def test_language_translate
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Language
-      res = dcatusNS.build(@@intMetadata)
+  def test_language_translate
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Language
+    res = dcatusNS.build(@@intMetadata)
 
-      assert_equal(%w[eng test_lang_code test_lang_code2], res)
-   end
+    assert_equal(%w[eng test_lang_code test_lang_code2], res)
+  end
 
-   def test_described_by_translate
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::DescribedBy
-      res = dcatusNS.build(@@intMetadata)
+  def test_described_by_translate
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::DescribedBy
+    res = dcatusNS.build(@@intMetadata)
 
-      assert_equal('http://test.something.org/10/F7DV1H10', res)
-   end
+    assert_equal('http://test.something.org/10/F7DV1H10', res)
+  end
 
-   def test_is_part_of_translate
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::IsPartOf
-      res = dcatusNS.build(@@intMetadata)
+  # def test_is_part_of_translate
+  #    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::IsPartOf
+  #    res = dcatusNS.build(@@intMetadata)
 
-      assert_equal('http://resource.associated.org/10/F7DV1H10', res)
-   end
+  #    assert_equal('http://resource.associated.org/10/F7DV1H10', res)
+  # end
 
-   def test_theme_translate
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Theme
-      res = dcatusNS.build(@@intMetadata)
+  def test_theme_translate
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Theme
+    res = dcatusNS.build(@@intMetadata)
 
-      expected = 'United States US Illinois IL Indiana IN Iowa IA Michigan '\
-      'MI Minnesota MN South Dakota SD Wisconsin WI'
+    expected = 'United States US Illinois IL Indiana IN Iowa IA Michigan '\
+    'MI Minnesota MN South Dakota SD Wisconsin WI'
 
-      assert_equal(expected, res)
-   end
+    assert_equal(expected, res)
+  end
 
-   def test_references_translate
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::References
-      res = dcatusNS.build(@@intMetadata)
+  def test_references_translate
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::References
+    res = dcatusNS.build(@@intMetadata)
 
-      expected = 'http://resource.associated.org/10/F7DV1H10,' \
-      'http://as0d1028h3.associated.org/10/F7DV1H10,'\
-      'http://dx.doi.org/10.5066/F7DV1H10,http://additional.doc/10/F7DV1H10,' \
-      'http://additional.doc/56/data.json'
+    expected = 'http://resource.associated.org/10/F7DV1H10,' \
+    'http://as0d1028h3.associated.org/10/F7DV1H10,'\
+    'http://dx.doi.org/10.5066/F7DV1H10,http://additional.doc/10/F7DV1H10,' \
+    'http://additional.doc/56/data.json'
 
-      assert_equal(expected, res)
-   end
+    assert_equal(expected, res)
+  end
 
-   def test_landing_page_translate
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::LandingPage
-      res = dcatusNS.build(@@intMetadata)
+  # def test_landing_page_translate
+  #    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::LandingPage
+  #    res = dcatusNS.build(@@intMetadata)
 
-      assert_equal('http://dx.doi.org/10.5066/F7DV1H10', res)
-   end
+  #    assert_equal('http://dx.doi.org/10.5066/F7DV1H10', res)
+  # end
 
-   def test_system_of_records_translate
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::SystemOfRecords
-      res = dcatusNS.build(@@intMetadata)
+  def test_system_of_records_translate
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::SystemOfRecords
+    res = dcatusNS.build(@@intMetadata)
 
-      assert_equal('http://as0d1028h3.associated.org/10/F7DV1H10', res)
-   end
+    assert_equal('http://as0d1028h3.associated.org/10/F7DV1H10', res)
+  end
 
-   def test_describe_by_type_translate
-      # describebytype returns the protocol of the first non-empty url str
-      # that doesnt end with '.html' which can produce nils. odd.
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::DescribedByType
-      res = dcatusNS.build(@@intMetadata)
+  def test_describe_by_type_translate
+    # describebytype returns the protocol of the first non-empty url str
+    # that doesnt end with '.html' which can produce nils. odd.
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::DescribedByType
+    res = dcatusNS.build(@@intMetadata)
 
-      assert_equal('https', res)
-   end
+    assert_equal('https', res)
+  end
 
-   def test_accrual_periodicity_translate
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::AccrualPeriodicity
-      res = dcatusNS.build(@@intMetadata)
+  # def test_accrual_periodicity_translate
+  #    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::AccrualPeriodicity
+  #    res = dcatusNS.build(@@intMetadata)
 
-      assert_equal('R/P2M or R/P0.5M', res)
-   end
+  #    assert_equal('R/P2M or R/P0.5M', res)
+  # end
 
-   def test_primaryit_investment_uii_translate
-      dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::PrimaryITInvestmentUII
-      res = dcatusNS.build(@@intMetadata)
+  def test_primaryit_investment_uii_translate
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::PrimaryITInvestmentUII
+    res = dcatusNS.build(@@intMetadata)
 
-      assert_equal('57d97341e4b090824ffb0e6f', res)
-   end
+    assert_equal('57d97341e4b090824ffb0e6f', res)
+  end
 
-   # skipping program code and bureau code...
+  # skipping program code and bureau code...
 
-   # TODO: fix and add back this test
-   #    def test_complete_translate
-   #       metadata = ADIWG::Mdtranslator.translate(
-   #          file: @@fileData, reader: 'iso19115_3', writer: 'dcat_us'
-   #       )
+  # TODO: fix and add back this test
+  #    def test_complete_translate
+  #       metadata = ADIWG::Mdtranslator.translate(
+  #          file: @@fileData, reader: 'iso19115_3', writer: 'dcat_us'
+  #       )
 
-   #       f = File.join(File.dirname(__FILE__), 'testData', 'iso19115-3-to-dcatus.json')
-   #       expected = File.open(f).read
+  #       f = File.join(File.dirname(__FILE__), 'testData', 'iso19115-3-to-dcatus.json')
+  #       expected = File.open(f).read
 
-   #       assert_equal('iso19115_3', metadata[:readerRequested])
-   #       assert_equal('dcat_us', metadata[:writerRequested])
-   #       assert_equal(true, metadata[:readerStructurePass])
-   #       assert_equal(true, metadata[:readerValidationPass])
-   #       assert_equal(true, metadata[:readerExecutionPass])
-   #       assert_equal(true, metadata[:writerPass])
-   #       assert_equal(expected.gsub(/\s+/, ''), metadata[:writerOutput].gsub(/\s+/, ''))
-   #    end
+  #       assert_equal('iso19115_3', metadata[:readerRequested])
+  #       assert_equal('dcat_us', metadata[:writerRequested])
+  #       assert_equal(true, metadata[:readerStructurePass])
+  #       assert_equal(true, metadata[:readerValidationPass])
+  #       assert_equal(true, metadata[:readerExecutionPass])
+  #       assert_equal(true, metadata[:writerPass])
+  #       assert_equal(expected.gsub(/\s+/, ''), metadata[:writerOutput].gsub(/\s+/, ''))
+  #    end
 end

--- a/test/translator/testData/iso19115-2-datagov-to-dcatus.json
+++ b/test/translator/testData/iso19115-2-datagov-to-dcatus.json
@@ -1,6 +1,7 @@
 {
   "@type": "dcat:Dataset",
   "title": "ISO19115-2 citation title test 123456",
+  "description": "abstract",
   "keyword": ["biota", "farming"],
   "modified": "2023-11-22T00:00:00+00:00",
   "publisher": {
@@ -12,19 +13,20 @@
     "fn": "test person test name",
     "hasEmail": "whatever@gmail.com"
   },
+  "identifier": "ISO19115-2-ID-123456",
   "accessLevel": "non-public",
   "bureauCode": [],
   "programCode": [],
   "distribution": [
     {
       "@type": "dcat:Distribution",
-      "description": "",
+      "description": "online resource description",
       "downloadURL": "online resource URL",
-      "mediaType": "format specification",
       "title": "online resource name"
     }
   ],
   "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "rights": "access constraint, classification, restricted",
   "spatial": "-74.0,24.0,-166.0,71.0",
   "temporal": "2017-12-01T00:00:00+00:00/2023-12-01T00:00:00+00:00",
   "issued": "2017-01-01T00:00:00+00:00",
@@ -32,8 +34,10 @@
   "language": ["eng"],
   "theme": "biota farming",
   "references": "aggregate_information_online_resources,aggregate_information_online_resources 12309u,https://aggregation_info_sample_url.gov",
+  "landingPage": "https://online_resource_url.gov",
+  "isPartOf": "associated resource title 1",
   "systemOfRecords": "aggregate_information_online_resources",
   "primaryITInvestmentUII": "ISO19115-2-ID-123456",
-  "describedBy": "https://datadictionaryhost.html",
-  "describedByType": "DD-WWW-123"
+  "describedBy": "https://datadictionaryhost.gov",
+  "describedByType": "HTTPS"
 }

--- a/test/translator/testData/iso19115-2.xml
+++ b/test/translator/testData/iso19115-2.xml
@@ -252,7 +252,7 @@
       <gmd:resourceMaintenance>
         <gmd:MD_MaintenanceInformation>
           <gmd:maintenanceAndUpdateFrequency>
-            <gmd:MD_MaintenanceFrequencyCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_MaintenanceFrequencyCode" codeListValue="resource maintenance frequency" codeSpace="userCode"/>
+            <gmd:MD_MaintenanceFrequencyCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_MaintenanceFrequencyCode" codeListValue="monthly" codeSpace="userCode"/>
           </gmd:maintenanceAndUpdateFrequency>
           <gmd:dateOfNextUpdate/>
           <gmd:updateScope/>

--- a/test/translator/testData/iso19115-2_datagov.xml
+++ b/test/translator/testData/iso19115-2_datagov.xml
@@ -252,7 +252,7 @@
       <gmd:resourceMaintenance>
         <gmd:MD_MaintenanceInformation>
           <gmd:maintenanceAndUpdateFrequency>
-            <gmd:MD_MaintenanceFrequencyCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_MaintenanceFrequencyCode" codeListValue="resource maintenance frequency" codeSpace="userCode"/>
+            <gmd:MD_MaintenanceFrequencyCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#MD_MaintenanceFrequencyCode" codeListValue="monthly" codeSpace="userCode"/>
           </gmd:maintenanceAndUpdateFrequency>
           <gmd:dateOfNextUpdate/>
           <gmd:updateScope/>
@@ -451,7 +451,7 @@
                </gmd:CI_Citation>
             </gmd:aggregateDataSetName>
             <gmd:associationType>
-            <gmd:DS_AssociationTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#DS_AssociationTypeCode" codeListValue="largerWorkCitation" codeSpace="002"/>
+            <gmd:DS_AssociationTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#DS_AssociationTypeCode" codeListValue="crossreference" codeSpace="002"/>
             </gmd:associationType>
             <gmd:initiativeType>
             <gmd:DS_InitiativeTypeCode codeList="http://mdtranslator.adiwg.org/api/codelists?format=xml#DS_InitiativeTypeCode" codeListValue="sorn" codeSpace="userCode"/>
@@ -1116,10 +1116,10 @@
                         <gmd:onlineResource>
                            <gmd:CI_OnlineResource>
                               <gmd:linkage>
-                                 <gmd:URL>https://datadictionaryhost.html</gmd:URL>
+                                 <gmd:URL>https://datadictionaryhost.gov</gmd:URL>
                               </gmd:linkage>
                               <gmd:protocol>
-                                 <gco:CharacterString>DD-WWW</gco:CharacterString>
+                                 <gco:CharacterString>HTTPS</gco:CharacterString>
                               </gmd:protocol>
                               <gmd:name>
                                  <gco:CharacterString>dd online resource name</gco:CharacterString>

--- a/test/writers/dcat_us/tc_dcat_us_distribution.rb
+++ b/test/writers/dcat_us/tc_dcat_us_distribution.rb
@@ -4,21 +4,24 @@ require 'adiwg-mdtranslator'
 require_relative 'dcat_us_test_parent'
 
 class TestWriterDcatUsDistribution < TestWriterDcatUsParent
+  # get input JSON for test
+  @@jsonIn = TestWriterDcatUsParent.getJson('distribution.json')
 
-   # get input JSON for test
-   @@jsonIn = TestWriterDcatUsParent.getJson('distribution.json')
+  def test_distribution
+    metadata = ADIWG::Mdtranslator.translate(
+      file: @@jsonIn, reader: 'mdJson', validate: 'normal',
+      writer: 'dcat_us', showAllTags: false
+    )
 
-   def test_distribution
-      metadata = ADIWG::Mdtranslator.translate(
-         file: @@jsonIn, reader: 'mdJson', validate: 'normal',
-         writer: 'dcat_us', showAllTags: false)
+    hJsonOut = JSON.parse(metadata[:writerOutput])
+    got = hJsonOut['distribution']
 
-      hJsonOut = JSON.parse(metadata[:writerOutput])
-      got = hJsonOut['distribution']
+    expect = [
+      { '@type' => 'dcat:Distribution', 'description' => 'distribution online resource description', 'downloadURL' => 'http://ISO.uri/adiwg/0',
+        'mediaType' => 'CSV', 'title' => '' },
+      { '@type' => 'dcat:Distribution', 'description' => 'distribution description', 'downloadURL' => 'http://ISO.uri/adiwg/3', 'mediaType' => 'Microsoft Excel', 'title' => '' }
+    ]
 
-      expect = [{"@type"=>"dcat:Distribution", "description"=>"Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.", "downloadURL"=>"http://ISO.uri/adiwg/0", "mediaType"=>"CSV", "title"=>""}]
-
-      assert_equal expect, got
-   end
-   
+    assert_equal expect, got
+  end
 end

--- a/test/writers/dcat_us/tc_dcat_us_identifier.rb
+++ b/test/writers/dcat_us/tc_dcat_us_identifier.rb
@@ -28,7 +28,7 @@ class TestWriterDcatUsIdentifier < TestWriterDcatUsParent
       hJsonOut = JSON.parse(metadata[:writerOutput])
       got = hJsonOut['identifier']
 
-      assert_equal 'http://myOnlineResource-doi.com', got
+      assert_equal 'myMetadataIdentifierID', got
    end
 
 end

--- a/test/writers/dcat_us/tc_dcat_us_is_part_of.rb
+++ b/test/writers/dcat_us/tc_dcat_us_is_part_of.rb
@@ -16,7 +16,7 @@ class TestWriterDcatUsIsPartOf < TestWriterDcatUsParent
       hJsonOut = JSON.parse(metadata[:writerOutput])
       got = hJsonOut['isPartOf']
 
-      expect = 'http://ISO.uri/adiwg/0'
+      expect = 'title'
 
       assert_equal expect, got
    end

--- a/test/writers/dcat_us/tc_dcat_us_references.rb
+++ b/test/writers/dcat_us/tc_dcat_us_references.rb
@@ -15,7 +15,7 @@ class TestWriterDcatUsReferences < TestWriterDcatUsParent
 
       hJsonOut = JSON.parse(metadata[:writerOutput])
       got = hJsonOut['references']
-
+      
       expect = 'http://ISO.uri/adiwg/0,http://ISO.uri/adiwg/1,http://ISO.uri/adiwg/2,http://ISO.uri/adiwg/3,http://ISO.uri/adiwg/4,http://ISO.uri/adiwg/5,http://ISO.uri/adiwg/6,http://ISO.uri/adiwg/7,http://ISO.uri/adiwg/8,http://ISO.uri/adiwg/9,http://ISO.uri/adiwg/10,http://ISO.uri/adiwg/11'
 
       assert_equal expect, got

--- a/test/writers/dcat_us/tc_dcat_us_rights.rb
+++ b/test/writers/dcat_us/tc_dcat_us_rights.rb
@@ -16,7 +16,7 @@ class TestWriterDcatUsRights < TestWriterDcatUsParent
       hJsonOut = JSON.parse(metadata[:writerOutput])
       got = hJsonOut['rights']
 
-      expect = 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. restricted unrestricted'
+      expect = 'otherRestrictions, non-public, in-confidence, secret'
 
       assert_equal expect, got
    end

--- a/test/writers/dcat_us/testData/accessLevel_nonPub.json
+++ b/test/writers/dcat_us/testData/accessLevel_nonPub.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/accessLevel_nonPub_legal.json
+++ b/test/writers/dcat_us/testData/accessLevel_nonPub_legal.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/accessLevel_nonPub_security.json
+++ b/test/writers/dcat_us/testData/accessLevel_nonPub_security.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/accessLevel_pub.json
+++ b/test/writers/dcat_us/testData/accessLevel_pub.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/accessLevel_resPub.json
+++ b/test/writers/dcat_us/testData/accessLevel_resPub.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/accessLevel_resPub_legal.json
+++ b/test/writers/dcat_us/testData/accessLevel_resPub_legal.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/accessLevel_resPub_security.json
+++ b/test/writers/dcat_us/testData/accessLevel_resPub_security.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/contactPoint.json
+++ b/test/writers/dcat_us/testData/contactPoint.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/describedBy.json
+++ b/test/writers/dcat_us/testData/describedBy.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/distribution.json
+++ b/test/writers/dcat_us/testData/distribution.json
@@ -2598,7 +2598,8 @@
                "transferSize": 9.9,
                "onlineOption": [
                  {
-                   "uri": "http://ISO.uri/adiwg/0"
+                   "uri": "http://ISO.uri/adiwg/0",
+                   "description": "distribution online resource description"
                  },
                  {
                    "uri": "http://ISO.uri/adiwg/1"
@@ -2649,7 +2650,8 @@
              {
                "transferSize": 10.9,
                "onlineOption": [{
-                 "uri": "http://ISO.uri/adiwg/3"
+                 "uri": "http://ISO.uri/adiwg/3",
+                 "description": "distribution description"
                }],
                "distributionFormat": [{
                  "formatSpecification": {

--- a/test/writers/dcat_us/testData/identifier.json
+++ b/test/writers/dcat_us/testData/identifier.json
@@ -13,7 +13,7 @@
    "metadata": {
       "metadataInfo": {
          "metadataIdentifier": {
-            "identifier": "myMetadataIdentifierID",
+            "identifier": "http://myOnlineResource-namespace.com",
             "namespace": "gov.sciencebase.catalog",
             "description": "metadata identifier"
          },
@@ -29,6 +29,11 @@
          ]
       },
       "resourceInfo": {
+         "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+         ],
          "resourceType": [
             {
                "type": "type",

--- a/test/writers/dcat_us/testData/identifier2.json
+++ b/test/writers/dcat_us/testData/identifier2.json
@@ -29,6 +29,11 @@
          ]
       },
       "resourceInfo": {
+         "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+         ],
          "resourceType": [
             {
                "type": "type",

--- a/test/writers/dcat_us/testData/isPartOf.json
+++ b/test/writers/dcat_us/testData/isPartOf.json
@@ -2441,7 +2441,7 @@
             "name": "name1"
           }
         ],
-        "associationType": "collectiveTitle",
+        "associationType": "largerWorkCitation",
         "initiativeType": "collection",
         "resourceCitation": {
           "title": "title",

--- a/test/writers/dcat_us/testData/issued.json
+++ b/test/writers/dcat_us/testData/issued.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/keyword.json
+++ b/test/writers/dcat_us/testData/keyword.json
@@ -29,6 +29,11 @@
         ]
      },
       "resourceInfo": {
+        "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+        ],
         "resourceType": [
           {
             "type": "tableDigital",

--- a/test/writers/dcat_us/testData/landingPage.json
+++ b/test/writers/dcat_us/testData/landingPage.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",
@@ -878,7 +883,7 @@
          "onlineResource": [
            {
              "uri": "http://ISO.uri/adiwg/0",
-             "function": "landingPage"
+             "function": "information"
            },
            {
              "uri": "http://ISO.uri/adiwg/1"

--- a/test/writers/dcat_us/testData/license.json
+++ b/test/writers/dcat_us/testData/license.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/modified.json
+++ b/test/writers/dcat_us/testData/modified.json
@@ -267,6 +267,11 @@
         ]
       },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/modified2.json
+++ b/test/writers/dcat_us/testData/modified2.json
@@ -267,6 +267,11 @@
         ]
       },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/publisher.json
+++ b/test/writers/dcat_us/testData/publisher.json
@@ -76,6 +76,11 @@
       ]
    },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/publisher2.json
+++ b/test/writers/dcat_us/testData/publisher2.json
@@ -228,6 +228,11 @@
       ]
     },
     "resourceInfo": {
+      "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
       "resourceType": [
         {
           "type": "tableDigital",

--- a/test/writers/dcat_us/testData/references.json
+++ b/test/writers/dcat_us/testData/references.json
@@ -688,6 +688,11 @@
         "metadataStatus": "notAccepted"
       },
       "resourceInfo": {
+        "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+        ],
         "resourceType": [
           {
             "type": "tableDigital",

--- a/test/writers/dcat_us/testData/rights.json
+++ b/test/writers/dcat_us/testData/rights.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/systemOfRecords.json
+++ b/test/writers/dcat_us/testData/systemOfRecords.json
@@ -688,6 +688,11 @@
         "metadataStatus": "notAccepted"
       },
       "resourceInfo": {
+        "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+        ],
         "resourceType": [
           {
             "type": "tableDigital",

--- a/test/writers/dcat_us/testData/temporal.json
+++ b/test/writers/dcat_us/testData/temporal.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/theme.json
+++ b/test/writers/dcat_us/testData/theme.json
@@ -688,6 +688,11 @@
        "metadataStatus": "notAccepted"
      },
      "resourceInfo": {
+       "resourceMaintenance": [
+          {
+            "frequency": "semiannual"
+          }
+       ],
        "resourceType": [
          {
            "type": "tableDigital",

--- a/test/writers/dcat_us/testData/title.json
+++ b/test/writers/dcat_us/testData/title.json
@@ -24,6 +24,11 @@
          ]
       },
       "resourceInfo": {
+         "resourceMaintenance": [
+            {
+               "frequency": "semiannual"
+            }
+         ],
          "resourceType": [
             {
                "type": "type",


### PR DESCRIPTION
## related tickets
- related to [#5056](https://github.com/GSA/data.gov/issues/5056)
- related to [#4862](https://github.com/GSA/data.gov/issues/4862)
- related to [#5046](https://github.com/GSA/data.gov/issues/5046)
- related to [#4565](https://github.com/GSA/data.gov/issues/4565)

## about
- fix ISO19115-2 to DCATUS mapping issues
- adds -1 reader

## notes
- mapping [notes v2](https://docs.google.com/spreadsheets/d/1hHJuLcfD4_Ql3F4MLeK3wAWaQ7PxKvrH/edit?gid=1049059080#gid=1049059080). "FALSE" values in white space were added in after the download and are meant to be ignored.
- the edits to the dcatus writer fixtures (.json files) are basically all the same. changes were made to the dcatus `AccrualPeriodicity` module to fix field mappings so the fixtures need to be updated too.

- this PR was submitted after the team made a pivot to consider [#5093](https://github.com/GSA/data.gov/issues/5093) in order for this work to be at a certain level of completeness and not uncertainty.

