### PR TITLE
pull all dates regardless of dateType and get the most recent.

### DIFF
--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_modified.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_modified.rb
@@ -1,29 +1,18 @@
 module ADIWG
-   module Mdtranslator
-      module Writers
-         module Dcat_us
-            module Modified
-
-               def self.build(intObj)
-                  resourceInfo = intObj[:metadata][:resourceInfo]
-                  citation = resourceInfo[:citation]
-                  dates = citation[:dates]
-
-                  mostRecentDate = nil
-
-                  dates.each do |date|
-                     if date[:dateType] == "lastUpdated" || date[:dateType] == "lastRevised" || date[:dateType] == "revision"
-                        if mostRecentDate.nil? || date[:date] > mostRecentDate
-                           mostRecentDate = date[:date]
-                        end
-                     end
-                  end
-
-                  return mostRecentDate
-               end               
-
-            end
-         end
+  module Mdtranslator
+    module Writers
+      module Dcat_us
+        module Modified
+          def self.build(intObj)
+            resourceInfo = intObj[:metadata][:resourceInfo]
+            citation = resourceInfo[:citation]
+            dates = citation[:dates]
+            # pulling from path 3 instead of path 2 in the
+            # iso19115 1 & 2 to dcatus mapping doc
+            dates.map { |d| d[:date] }.compact.sort!.last
+          end
+        end
       end
-   end
+    end
+  end
 end


### PR DESCRIPTION
@btylerburton 

loosening how we get our modified date by removing conditional against date dateType. This is path 3 for modified in the dcatus_to_iso19115_2 mapping [doc](https://docs.google.com/spreadsheets/d/1hHJuLcfD4_Ql3F4MLeK3wAWaQ7PxKvrH/edit?gid=1049059080#gid=1049059080).

related to [5181](https://github.com/GSA/data.gov/issues/5181)