### PR TITLE
add mailto prefix to email for contactPoint

### DIFF
--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_contact_point.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_contact_point.rb
@@ -12,13 +12,16 @@ module ADIWG
             fn = ''
             hasEmail = ''
 
-            unless pointOfContact.nil?
-              contactId = pointOfContact[:parties][0][:contactId]
+            return if pointOfContact.nil?
 
-              contact = Dcat_us.get_contact_by_id(contactId)
-              fn = contact[:name]
-              hasEmail = contact[:eMailList][0]
-            end
+            contactId = pointOfContact[:parties][0][:contactId]
+
+            contact = Dcat_us.get_contact_by_id(contactId)
+            fn = contact[:name]
+            hasEmail = contact[:eMailList][0]
+
+            # there's an email and it doesn't already start with "mailto:"
+            hasEmail = "mailto:#{hasEmail}" if !hasEmail.nil? && (!hasEmail.start_with? 'mailto:')
 
             Jbuilder.new do |json|
               json.set!('@type', 'vcard:Contact')

--- a/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
+++ b/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
@@ -98,7 +98,7 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
     res = ADIWG::Mdtranslator::Writers::Dcat_us.startWriter(intMetadata, @@hResponse)
     data = JSON.parse res
 
-    expected = JSON.parse '{"@type":"vcard:Contact", "fn":"test person test name", "hasEmail":"whatever@gmail.com"}'
+    expected = JSON.parse '{"@type":"vcard:Contact", "fn":"test person test name", "hasEmail":"mailto:whatever@gmail.com"}'
     assert_equal(expected, data['contactPoint'])
   end
 

--- a/test/translator/testData/iso19115-2-datagov-to-dcatus.json
+++ b/test/translator/testData/iso19115-2-datagov-to-dcatus.json
@@ -11,7 +11,7 @@
   "contactPoint": {
     "@type": "vcard:Contact",
     "fn": "test person test name",
-    "hasEmail": "whatever@gmail.com"
+    "hasEmail": "mailto:whatever@gmail.com"
   },
   "identifier": "ISO19115-2-ID-123456",
   "accessLevel": "non-public",

--- a/test/writers/dcat_us/tc_dcat_us_contact_point.rb
+++ b/test/writers/dcat_us/tc_dcat_us_contact_point.rb
@@ -4,21 +4,20 @@ require 'adiwg-mdtranslator'
 require_relative 'dcat_us_test_parent'
 
 class TestWriterDcatUsContactPoint < TestWriterDcatUsParent
+  # get input JSON for test
+  @@jsonIn = TestWriterDcatUsParent.getJson('contactPoint.json')
 
-   # get input JSON for test
-   @@jsonIn = TestWriterDcatUsParent.getJson('contactPoint.json')
+  def test_sample
+    metadata = ADIWG::Mdtranslator.translate(
+      file: @@jsonIn, reader: 'mdJson', validate: 'normal',
+      writer: 'dcat_us', showAllTags: false
+    )
 
-   def test_sample
-      metadata = ADIWG::Mdtranslator.translate(
-         file: @@jsonIn, reader: 'mdJson', validate: 'normal',
-         writer: 'dcat_us', showAllTags: false)
+    hJsonOut = JSON.parse(metadata[:writerOutput])
+    got = hJsonOut['contactPoint']
 
-      hJsonOut = JSON.parse(metadata[:writerOutput])
-      got = hJsonOut['contactPoint']
+    expect = { '@type' => 'vcard:Contact', 'fn' => 'Stan Smith', 'hasEmail' => 'mailto:e.mail@address.com1' }
 
-      expect = {"@type"=>"vcard:Contact", "fn"=>"Stan Smith", "hasEmail"=>"e.mail@address.com1"}
-
-      assert_equal expect, got
-   end
-   
+    assert_equal expect, got
+  end
 end


### PR DESCRIPTION
adding `mailto:` prefix to contactPoint email data