### PR TITLE
add minor fixes

### DIFF
--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
@@ -23,10 +23,10 @@ module ADIWG
                   transfer[:onlineOptions]&.each do |option|
                     next unless option[:olResURI]
 
-                    description = option[:olResDesc] || ''
+                    description = option[:olResDesc] || nil
                     accessURL = AccessURL.build(option)
                     downloadURL = DownloadURL.build(option)
-                    title = option[:olResName] || ''
+                    title = option[:olResName] || nil
 
                     distribution = Jbuilder.new do |json|
                       json.set!('@type', 'dcat:Distribution')

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_keyword.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_keyword.rb
@@ -1,19 +1,17 @@
 module ADIWG
-   module Mdtranslator
-      module Writers
-         module Dcat_us
-            module Keyword
- 
-               def self.build(intObj)
-                  resourceInfo = intObj.dig(:metadata, :resourceInfo)
-                  keywords = resourceInfo&.dig(:keywords)
-                
-                  return keywords&.flat_map { |keyword| keyword[:keywords]&.map { |kw| kw[:keyword] } } || []
-                end                
-                
-            end
-         end
+  module Mdtranslator
+    module Writers
+      module Dcat_us
+        module Keyword
+          def self.build(intObj)
+            resourceInfo = intObj.dig(:metadata, :resourceInfo)
+            keywords = resourceInfo&.dig(:keywords)
+            keywords = keywords&.flat_map { |keyword| keyword[:keywords]&.map { |kw| kw[:keyword] } }
+
+            keywords.reject(&:empty?)
+          end
+        end
       end
-   end
+    end
+  end
 end
- 

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_references.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_references.rb
@@ -41,7 +41,7 @@ module ADIWG
 
             return nil if uris.empty?
 
-            uris
+            uris.uniq
           end
         end
       end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_theme.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_theme.rb
@@ -19,7 +19,7 @@ module ADIWG
 
             return nil if keywords_str.empty?
 
-            keywords_str
+            keywords_str.reject(&:empty?)
           end
         end
       end

--- a/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
+++ b/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
@@ -211,6 +211,11 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
     intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
 
     dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::References
+
+    # add a duplicate to check against uniqueness in the output
+    dup = intMetadata[:metadata][:associatedResources][0][:resourceCitation][:onlineResources][0]
+    intMetadata[:metadata][:associatedResources][0][:resourceCitation][:onlineResources] << dup
+
     res = dcatusNS.build(intMetadata)
 
     expected = ['aggregate_information_online_resources',

--- a/test/translator/testData/iso19115-2_datagov.xml
+++ b/test/translator/testData/iso19115-2_datagov.xml
@@ -289,6 +289,9 @@
       <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>
           <gmd:keyword>
+            <gco:CharacterString />
+          </gmd:keyword>
+          <gmd:keyword>
             <gco:CharacterString>biota</gco:CharacterString>
           </gmd:keyword>
           <gmd:keyword>

--- a/test/writers/dcat_us/tc_dcat_us_distribution.rb
+++ b/test/writers/dcat_us/tc_dcat_us_distribution.rb
@@ -18,9 +18,9 @@ class TestWriterDcatUsDistribution < TestWriterDcatUsParent
 
     expect = [
       { '@type' => 'dcat:Distribution', 'description' => 'distribution online resource description',
-        'downloadURL' => 'http://ISO.uri/adiwg/0', 'mediaType' => 'placeholder/value', 'title' => '' },
+        'downloadURL' => 'http://ISO.uri/adiwg/0', 'mediaType' => 'placeholder/value' },
       { '@type' => 'dcat:Distribution', 'description' => 'distribution description', 'downloadURL' =>
-        'http://ISO.uri/adiwg/3', 'mediaType' => 'placeholder/value', 'title' => '' }
+        'http://ISO.uri/adiwg/3', 'mediaType' => 'placeholder/value' }
     ]
 
     assert_equal expect, got


### PR DESCRIPTION
- makes distribution description and title nil default instead of empty string
- remove empty strings from keywords and theme (found this out during local testing and figured why not include it)
- make dcatus references array unique

related to [#5204](https://github.com/GSA/data.gov/issues/5204)
related to [#5208](https://github.com/GSA/data.gov/issues/5208)
related to [#5202](https://github.com/GSA/data.gov/issues/5202)