### PR TITLE
add datestamp processing

### DIFF
--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_modified.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_modified.rb
@@ -9,7 +9,13 @@ module ADIWG
             dates = citation[:dates]
             # pulling from path 3 instead of path 2 in the
             # iso19115 1 & 2 to dcatus mapping doc
-            dates.map { |d| d[:date] }.compact.sort!.last
+            opt1 = dates.map { |d| d[:date] }.compact.sort!.last
+            return opt1 unless opt1.nil?
+
+            opt2 = intObj.dig(:metadata, :metadataInfo, :metadataDates, 0)
+            return if opt2.nil?
+
+            opt2.key?(:date) ? opt2[:date] : opt2[:dateTime]
           end
         end
       end

--- a/test/readers/iso19115_2_datagov/tc_iso19115_2_metadata_info.rb
+++ b/test/readers/iso19115_2_datagov/tc_iso19115_2_metadata_info.rb
@@ -4,6 +4,7 @@
 # readers / iso19115-2 / module_metadata
 
 require 'adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_metadata_info'
+require 'date'
 require_relative 'iso19115_2_test_parent'
 
 class TestReaderIso191152datagovMetadataInformation < TestReaderIso191152datagovParent
@@ -24,7 +25,47 @@ class TestReaderIso191152datagovMetadataInformation < TestReaderIso191152datagov
     assert_equal({ identifier: 'ISO19115-2-ID-123456' }, hDictionary[:metadataIdentifier])
     assert_equal({ identifier: [{ identifier: 'ISO19115-2-ID-123456-parent' }] },
                  hDictionary[:parentMetadata])
+    assert_equal(DateTime.new(2023, 6, 23), hDictionary[:metadataDates][0][:date])
     refute_empty hDictionary[:metadataMaintenance]
     refute_empty hDictionary[:defaultMetadataLocale]
+  end
+
+  def test_missing_datestamp
+    xDoc = TestReaderIso191152datagovParent.get_xml('iso19115-2_no_datestamp.xml')
+
+    TestReaderIso191152datagovParent.set_xdoc(xDoc)
+
+    xIn = xDoc.xpath('gmi:MI_Metadata')[0]
+    hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
+    @@nameSpace.unpack(xIn, hResponse)
+
+    expected = ["WARNING: ISO19115-2 reader: element 'gmd:dateStamp' is missing in MI_Metadata"]
+    assert_equal(hResponse[:readerValidationMessages], expected)
+  end
+
+  def test_valid_nilreason_datestamp
+    xDoc = TestReaderIso191152datagovParent.get_xml('iso19115-2_datestamp_nilreason.xml')
+
+    TestReaderIso191152datagovParent.set_xdoc(xDoc)
+
+    xIn = xDoc.xpath('gmi:MI_Metadata')[0]
+    hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
+    @@nameSpace.unpack(xIn, hResponse)
+
+    expected = ["INFO: ISO19115-2 reader: element 'dateStamp' contains acceptable nilReason: 'unknown'"]
+    assert_equal(hResponse[:readerValidationMessages], expected)
+  end
+
+  def test_invalid_nilreason_datestamp
+    xDoc = TestReaderIso191152datagovParent.get_xml('iso19115-2_datestamp_no_nilreason.xml')
+
+    TestReaderIso191152datagovParent.set_xdoc(xDoc)
+
+    xIn = xDoc.xpath('gmi:MI_Metadata')[0]
+    hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
+    @@nameSpace.unpack(xIn, hResponse)
+
+    expected = ["WARNING: ISO19115-2 reader: element 'gmd:dateStamp' is missing valid nil reason within 'MI_Metadata'"]
+    assert_equal(hResponse[:readerValidationMessages], expected)
   end
 end

--- a/test/readers/iso19115_2_datagov/testData/iso19115-2.xml
+++ b/test/readers/iso19115_2_datagov/testData/iso19115-2.xml
@@ -23,6 +23,9 @@
   <gmd:fileIdentifier>
     <gco:CharacterString>ISO19115-2-ID-123456</gco:CharacterString>
   </gmd:fileIdentifier>
+  <gmd:dateStamp>
+    <gco:Date>2023-06-23</gco:Date>
+  </gmd:dateStamp>
   <gmd:locale>
     <gmd:PT_Locale>
       <gmd:languageCode>

--- a/test/readers/iso19115_2_datagov/testData/iso19115-2_datestamp_nilreason.xml
+++ b/test/readers/iso19115_2_datagov/testData/iso19115-2_datestamp_nilreason.xml
@@ -20,9 +20,6 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.isotc211.org/2005/gmi
         ftp://ftp.ncddc.noaa.gov/pub/Metadata/Online_ISO_Training/Intro_to_ISO/schemas/ISObio/schema.xsd">
-  <gmd:identificationInfo/>
-  <gmd:contact nilReason="unknown"></gmd:contact>
-  <gmd:dateStamp>
-    <gco:Date>2023-06-23</gco:Date>
-  </gmd:dateStamp>
+  <gmd:contact gco:nilReason="unknown"></gmd:contact>
+  <gmd:dateStamp gco:nilReason="unknown"></gmd:dateStamp>
 </gmi:MI_Metadata>

--- a/test/readers/iso19115_2_datagov/testData/iso19115-2_datestamp_no_nilreason.xml
+++ b/test/readers/iso19115_2_datagov/testData/iso19115-2_datestamp_no_nilreason.xml
@@ -20,9 +20,6 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.isotc211.org/2005/gmi
         ftp://ftp.ncddc.noaa.gov/pub/Metadata/Online_ISO_Training/Intro_to_ISO/schemas/ISObio/schema.xsd">
-  <gmd:identificationInfo/>
-  <gmd:contact nilReason="unknown"></gmd:contact>
-  <gmd:dateStamp>
-    <gco:Date>2023-06-23</gco:Date>
-  </gmd:dateStamp>
+  <gmd:contact gco:nilReason="unknown"></gmd:contact>
+  <gmd:dateStamp></gmd:dateStamp>
 </gmi:MI_Metadata>

--- a/test/readers/iso19115_2_datagov/testData/iso19115-2_metadata_yes_nilreasons.xml
+++ b/test/readers/iso19115_2_datagov/testData/iso19115-2_metadata_yes_nilreasons.xml
@@ -22,4 +22,7 @@
         ftp://ftp.ncddc.noaa.gov/pub/Metadata/Online_ISO_Training/Intro_to_ISO/schemas/ISObio/schema.xsd">
   <gmd:identificationInfo gco:nilReason="missing"/>
   <gmd:contact nilReason="unknown"></gmd:contact>
+  <gmd:dateStamp>
+    <gco:Date>2023-06-23</gco:Date>
+  </gmd:dateStamp>
 </gmi:MI_Metadata>

--- a/test/readers/iso19115_2_datagov/testData/iso19115-2_no_datestamp.xml
+++ b/test/readers/iso19115_2_datagov/testData/iso19115-2_no_datestamp.xml
@@ -20,9 +20,5 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.isotc211.org/2005/gmi
         ftp://ftp.ncddc.noaa.gov/pub/Metadata/Online_ISO_Training/Intro_to_ISO/schemas/ISObio/schema.xsd">
-  <gmd:identificationInfo/>
   <gmd:contact nilReason="unknown"></gmd:contact>
-  <gmd:dateStamp>
-    <gco:Date>2023-06-23</gco:Date>
-  </gmd:dateStamp>
 </gmi:MI_Metadata>

--- a/test/readers/iso19115_2_datagov/testData/iso19115-2_no_idinfo.xml
+++ b/test/readers/iso19115_2_datagov/testData/iso19115-2_no_idinfo.xml
@@ -21,4 +21,7 @@
         xsi:schemaLocation="http://www.isotc211.org/2005/gmi
         ftp://ftp.ncddc.noaa.gov/pub/Metadata/Online_ISO_Training/Intro_to_ISO/schemas/ISObio/schema.xsd">
   <gmd:contact nilReason="unknown"></gmd:contact>
+  <gmd:dateStamp>
+    <gco:Date>2023-06-23</gco:Date>
+  </gmd:dateStamp>
 </gmi:MI_Metadata>

--- a/test/translator/testData/iso19115-2_datagov.xml
+++ b/test/translator/testData/iso19115-2_datagov.xml
@@ -23,6 +23,9 @@
   <gmd:fileIdentifier>
     <gco:CharacterString>ISO19115-2-ID-123456</gco:CharacterString>
   </gmd:fileIdentifier>
+  <gmd:dateStamp>
+    <gco:DateTime>2023-06-23</gco:DateTime>
+  </gmd:dateStamp>
   <gmd:locale>
     <gmd:PT_Locale>
       <gmd:languageCode>


### PR DESCRIPTION
related to [#5201](https://github.com/GSA/data.gov/issues/5201)

- add dateStamp processing. 
- updates fixtures because it's a required element.
- add tests for when it exists, when it doesn't, and when it contains a valid nilReason.