### PR TITLE
add more contact processing in dcatus writer

### DIFF
--- a/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/iso19115_2_datagov_reader.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/iso19115_2_datagov_reader.rb
@@ -34,7 +34,7 @@ module ADIWG
           AdiwgUtils.add_iso19115_namespaces(xDoc) # registers in-place
 
           # file must contain an ISO 19115-2 <gmi:MI_Metadata> tag
-          xMetadata = xDoc.xpath(@@rootXPath)
+          xMetadata = xDoc.xpath(@@rootXPath)[0]
           if xMetadata.nil?
             msg = "ERROR: ISO 19115-2 file did not contain a #{@@rootXPath} tag"
             hResponseObj[:readerValidationMessages] << msg

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_contact_point.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_contact_point.rb
@@ -7,18 +7,36 @@ module ADIWG
         module ContactPoint
           def self.build(intObj)
             resourceInfo = intObj[:metadata][:resourceInfo]
-            pointOfContact = resourceInfo[:pointOfContacts][0]
+            pointOfContact = resourceInfo.dig(:pointOfContacts, 0, :parties, 0)
+
+            return if pointOfContact.nil?
 
             fn = ''
             hasEmail = ''
 
-            return if pointOfContact.nil?
+            # TODO: revisit contacts but this should do what we want for ISO
+            # the idea here is to check in 2 spots for contact information. if the
+            # first one doesn't contain both a non-nil full name (fn) and email
+            # then attempt the other one.
+            if pointOfContact.key?(:name)
+              if !pointOfContact[:name].nil? && !pointOfContact[:eMailList][0].nil?
+                fn = pointOfContact[:name]
+                hasEmail = pointOfContact[:eMailList][0]
+              else
+                pointOfContact = intObj.dig(:metadata, :metadataInfo, :metadataContacts, 0, :parties, 0)
+                unless pointOfContact.nil?
+                  fn = pointOfContact[:name]
+                  hasEmail = pointOfContact[:eMailList][0]
+                end
+              end
+            else
+              contactId = pointOfContact[:contactId]
 
-            contactId = pointOfContact[:parties][0][:contactId]
+              contact = Dcat_us.get_contact_by_id(contactId)
 
-            contact = Dcat_us.get_contact_by_id(contactId)
-            fn = contact[:name]
-            hasEmail = contact[:eMailList][0]
+              fn = contact[:name]
+              hasEmail = contact[:eMailList][0]
+            end
 
             # there's an email and it doesn't already start with "mailto:"
             hasEmail = "mailto:#{hasEmail}" if !hasEmail.nil? && (!hasEmail.start_with? 'mailto:')

--- a/test/readers/iso19115_2_datagov/tc_iso19115_2_metadata.rb
+++ b/test/readers/iso19115_2_datagov/tc_iso19115_2_metadata.rb
@@ -32,7 +32,10 @@ class TestReaderIso191152datagovMetadata < TestReaderIso191152datagovParent
     hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
     _hDictionary = @@nameSpace.unpack(xIn, hResponse)
 
-    assert_equal(["WARNING: ISO19115-2 reader: element 'gmd:identificationInfo' is missing in MI_Metadata"],
+    expected = ["WARNING: ISO19115-2 reader: element 'gmd:identificationInfo' is missing in MI_Metadata",
+                "INFO: ISO19115-2 reader: element 'contact' contains acceptable nilReason: 'unknown'"]
+
+    assert_equal(expected,
                  hResponse[:readerValidationMessages])
     assert_equal(false, hResponse[:readerValidationPass])
   end
@@ -46,8 +49,8 @@ class TestReaderIso191152datagovMetadata < TestReaderIso191152datagovParent
     _hDictionary = @@nameSpace.unpack(xIn, hResponse)
 
     warnings = [
-      "WARNING: ISO19115-2 reader: element 'identificationInfo' is missing valid " \
-      "nil reason within 'MI_Metadata'"
+      "WARNING: ISO19115-2 reader: element 'identificationInfo' is missing valid nil reason within 'MI_Metadata'",
+      "INFO: ISO19115-2 reader: element 'contact' contains acceptable nilReason: 'unknown'"
     ]
 
     assert_equal(warnings, hResponse[:readerValidationMessages])
@@ -62,9 +65,8 @@ class TestReaderIso191152datagovMetadata < TestReaderIso191152datagovParent
     hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
     _hDictionary = @@nameSpace.unpack(xIn, hResponse)
 
-    infos = [
-      "INFO: ISO19115-2 reader: element 'identificationInfo' contains acceptable nilReason: 'missing'"
-    ]
+    infos = ["INFO: ISO19115-2 reader: element 'identificationInfo' contains acceptable nilReason: 'missing'",
+             "INFO: ISO19115-2 reader: element 'contact' contains acceptable nilReason: 'unknown'"]
 
     assert_equal(infos, hResponse[:readerValidationMessages])
     assert_equal(true, hResponse[:readerValidationPass])

--- a/test/readers/iso19115_2_datagov/tc_iso19115_2_metadata_info.rb
+++ b/test/readers/iso19115_2_datagov/tc_iso19115_2_metadata_info.rb
@@ -39,7 +39,8 @@ class TestReaderIso191152datagovMetadataInformation < TestReaderIso191152datagov
     hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
     @@nameSpace.unpack(xIn, hResponse)
 
-    expected = ["WARNING: ISO19115-2 reader: element 'gmd:dateStamp' is missing in MI_Metadata"]
+    expected = ["INFO: ISO19115-2 reader: element 'contact' contains acceptable nilReason: 'unknown'",
+                "WARNING: ISO19115-2 reader: element 'gmd:dateStamp' is missing in MI_Metadata"]
     assert_equal(hResponse[:readerValidationMessages], expected)
   end
 
@@ -52,7 +53,8 @@ class TestReaderIso191152datagovMetadataInformation < TestReaderIso191152datagov
     hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
     @@nameSpace.unpack(xIn, hResponse)
 
-    expected = ["INFO: ISO19115-2 reader: element 'dateStamp' contains acceptable nilReason: 'unknown'"]
+    expected = ["INFO: ISO19115-2 reader: element 'contact' contains acceptable nilReason: 'unknown'",
+                "INFO: ISO19115-2 reader: element 'dateStamp' contains acceptable nilReason: 'unknown'"]
     assert_equal(hResponse[:readerValidationMessages], expected)
   end
 
@@ -65,7 +67,36 @@ class TestReaderIso191152datagovMetadataInformation < TestReaderIso191152datagov
     hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
     @@nameSpace.unpack(xIn, hResponse)
 
-    expected = ["WARNING: ISO19115-2 reader: element 'gmd:dateStamp' is missing valid nil reason within 'MI_Metadata'"]
+    expected = ["INFO: ISO19115-2 reader: element 'contact' contains acceptable nilReason: 'unknown'",
+                "WARNING: ISO19115-2 reader: element 'gmd:dateStamp' is missing valid nil reason within 'MI_Metadata'"]
+    assert_equal(hResponse[:readerValidationMessages], expected)
+  end
+
+  def test_missing_contact
+    xDoc = TestReaderIso191152datagovParent.get_xml('iso19115-2_metatadata_missing_contact.xml')
+
+    TestReaderIso191152datagovParent.set_xdoc(xDoc)
+
+    xIn = xDoc.xpath('gmi:MI_Metadata')[0]
+    hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
+    @@nameSpace.unpack(xIn, hResponse)
+
+    expected = ["WARNING: ISO19115-2 reader: element 'gmd:contact' is missing in MI_Metadata"]
+    assert_equal(hResponse[:readerValidationMessages], expected)
+  end
+
+  # we don't need a test_valid_nilreason_contact because the above
+  # tests assert that works correctly
+  def test_invalid_nilreason_contact
+    xDoc = TestReaderIso191152datagovParent.get_xml('iso19115-2_metatadata_contact_no_nilreason.xml')
+
+    TestReaderIso191152datagovParent.set_xdoc(xDoc)
+
+    xIn = xDoc.xpath('gmi:MI_Metadata')[0]
+    hResponse = Marshal.load(Marshal.dump(@@hResponseObj))
+    @@nameSpace.unpack(xIn, hResponse)
+
+    expected = ["WARNING: ISO19115-2 reader: element 'gmd:contact' is missing valid nil reason within 'MI_Metadata'"]
     assert_equal(hResponse[:readerValidationMessages], expected)
   end
 end

--- a/test/readers/iso19115_2_datagov/testData/iso19115-2_metadata_no_nilreasons.xml
+++ b/test/readers/iso19115_2_datagov/testData/iso19115-2_metadata_no_nilreasons.xml
@@ -21,7 +21,7 @@
         xsi:schemaLocation="http://www.isotc211.org/2005/gmi
         ftp://ftp.ncddc.noaa.gov/pub/Metadata/Online_ISO_Training/Intro_to_ISO/schemas/ISObio/schema.xsd">
   <gmd:identificationInfo/>
-  <gmd:contact nilReason="unknown"></gmd:contact>
+  <gmd:contact gco:nilReason="unknown"></gmd:contact>
   <gmd:dateStamp>
     <gco:Date>2023-06-23</gco:Date>
   </gmd:dateStamp>

--- a/test/readers/iso19115_2_datagov/testData/iso19115-2_metadata_yes_nilreasons.xml
+++ b/test/readers/iso19115_2_datagov/testData/iso19115-2_metadata_yes_nilreasons.xml
@@ -21,7 +21,7 @@
         xsi:schemaLocation="http://www.isotc211.org/2005/gmi
         ftp://ftp.ncddc.noaa.gov/pub/Metadata/Online_ISO_Training/Intro_to_ISO/schemas/ISObio/schema.xsd">
   <gmd:identificationInfo gco:nilReason="missing"/>
-  <gmd:contact nilReason="unknown"></gmd:contact>
+  <gmd:contact gco:nilReason="unknown"></gmd:contact>
   <gmd:dateStamp>
     <gco:Date>2023-06-23</gco:Date>
   </gmd:dateStamp>

--- a/test/readers/iso19115_2_datagov/testData/iso19115-2_metatadata_contact_no_nilreason.xml
+++ b/test/readers/iso19115_2_datagov/testData/iso19115-2_metatadata_contact_no_nilreason.xml
@@ -20,5 +20,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.isotc211.org/2005/gmi
         ftp://ftp.ncddc.noaa.gov/pub/Metadata/Online_ISO_Training/Intro_to_ISO/schemas/ISObio/schema.xsd">
-  <gmd:contact gco:nilReason="unknown"></gmd:contact>
+  <gmd:contact></gmd:contact>
+  <gmd:dateStamp>
+    <gco:Date>2023-06-23</gco:Date>
+  </gmd:dateStamp>
 </gmi:MI_Metadata>

--- a/test/readers/iso19115_2_datagov/testData/iso19115-2_metatadata_missing_contact.xml
+++ b/test/readers/iso19115_2_datagov/testData/iso19115-2_metatadata_missing_contact.xml
@@ -20,5 +20,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.isotc211.org/2005/gmi
         ftp://ftp.ncddc.noaa.gov/pub/Metadata/Online_ISO_Training/Intro_to_ISO/schemas/ISObio/schema.xsd">
-  <gmd:contact gco:nilReason="unknown"></gmd:contact>
+  <gmd:dateStamp>
+    <gco:Date>2023-06-23</gco:Date>
+  </gmd:dateStamp>
 </gmi:MI_Metadata>

--- a/test/readers/iso19115_2_datagov/testData/iso19115-2_no_idinfo.xml
+++ b/test/readers/iso19115_2_datagov/testData/iso19115-2_no_idinfo.xml
@@ -20,7 +20,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.isotc211.org/2005/gmi
         ftp://ftp.ncddc.noaa.gov/pub/Metadata/Online_ISO_Training/Intro_to_ISO/schemas/ISObio/schema.xsd">
-  <gmd:contact nilReason="unknown"></gmd:contact>
+  <gmd:contact gco:nilReason="unknown"></gmd:contact>
   <gmd:dateStamp>
     <gco:Date>2023-06-23</gco:Date>
   </gmd:dateStamp>


### PR DESCRIPTION
related to [#5203](https://github.com/GSA/data.gov/issues/5203)

- add more contact processing in dcatus contactpoint 
- add nil reason check for contact in metadata info
- update tests and fixtures
- minor bug fix
