### PR TITLE
update contact processing

### DIFF
--- a/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_responsibility.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_responsibility.rb
@@ -99,9 +99,16 @@ module ADIWG
             xEmails = xRParty.xpath(@@emailXPath)
             hContact[:eMailList] = xEmails.map(&:text).compact
 
-            Iso191152datagov.set_contact(hContact)
+            contactIdx = Iso191152datagov.set_contact(hContact)
 
-            hRespblty[:parties] = [hContact]
+            hParty = intMetadataClass.newParty
+            hParty[:contactId] = hContact[:contactId]
+            hParty[:contactIndex] = contactIdx
+            hParty[:contactType] = hContact[:contactType]
+            hParty[:contactName] = hContact[:contactName]
+            # :organizationMembers skipping for now.
+
+            hRespblty[:parties] = [hParty]
 
             hRespblty
           end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_contact_point.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_contact_point.rb
@@ -7,36 +7,30 @@ module ADIWG
         module ContactPoint
           def self.build(intObj)
             resourceInfo = intObj[:metadata][:resourceInfo]
-            pointOfContact = resourceInfo.dig(:pointOfContacts, 0, :parties, 0)
-
-            return if pointOfContact.nil?
+            pointOfContactOpt1 = resourceInfo.dig(:pointOfContacts, 0, :parties, 0)
+            pointOfContactOpt2 = intObj.dig(:metadata, :metadataInfo, :metadataContacts, 0, :parties, 0)
+            options = [pointOfContactOpt1, pointOfContactOpt2].compact
 
             fn = ''
             hasEmail = ''
 
-            # TODO: revisit contacts but this should do what we want for ISO
-            # the idea here is to check in 2 spots for contact information. if the
-            # first one doesn't contain both a non-nil full name (fn) and email
-            # then attempt the other one.
-            if pointOfContact.key?(:name)
-              if !pointOfContact[:name].nil? && !pointOfContact[:eMailList][0].nil?
-                fn = pointOfContact[:name]
-                hasEmail = pointOfContact[:eMailList][0]
-              else
-                pointOfContact = intObj.dig(:metadata, :metadataInfo, :metadataContacts, 0, :parties, 0)
-                unless pointOfContact.nil?
-                  fn = pointOfContact[:name]
-                  hasEmail = pointOfContact[:eMailList][0]
-                end
+            options.each do |option|
+              # skip if we already have a fullname and email
+              next if !fn.empty? && !hasEmail.empty?
+
+              # Dcat_us functions (parent module to ContactPoint) aren't available here
+              # when unit testing so replicating the logic here.
+              contact = intObj[:contacts].select { |c| c[:contactId] == option[:contactId] }[0]
+              name = contact[:name]
+              email = contact[:eMailList][0]
+
+              if !name.nil? && !email.nil?
+                fn = name
+                hasEmail = email
               end
-            else
-              contactId = pointOfContact[:contactId]
-
-              contact = Dcat_us.get_contact_by_id(contactId)
-
-              fn = contact[:name]
-              hasEmail = contact[:eMailList][0]
             end
+
+            return nil if fn.empty? | hasEmail.empty?
 
             # there's an email and it doesn't already start with "mailto:"
             hasEmail = "mailto:#{hasEmail}" if !hasEmail.nil? && (!hasEmail.start_with? 'mailto:')

--- a/test/readers/iso19115_2_datagov/tc_iso19115_2_responsibility.rb
+++ b/test/readers/iso19115_2_datagov/tc_iso19115_2_responsibility.rb
@@ -23,12 +23,8 @@ class TestReaderIso191152datagovResponsibility < TestReaderIso191152datagovParen
     assert_equal(1, hDictionary[:parties].size)
 
     party = hDictionary[:parties][0]
-    assert_equal(true, party[:isOrganization])
-    assert_equal('citation organization name', party[:name])
     assert_equal('organization', party[:contactType])
     assert_equal('citation organization name', party[:contactName])
-
-    assert_equal(['test@gmail.com'], party[:eMailList])
   end
 
   def test_responsibility_no_role_code

--- a/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
+++ b/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
@@ -74,7 +74,7 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
     dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Publisher
     res = dcatusNS.build(intMetadata).target!
 
-    expected = '{"@type":"org:Organization","name":"Office of National Marine Sanctuaries"}'
+    expected = '{"@type":"org:Organization","name":"citation organization name"}'
     assert_equal(expected, res)
   end
 
@@ -92,12 +92,12 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
 
   def test_contact_point
     intMetadata = @@iso191152NS.unpack(@@xIn, @@hResponse)
+    dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::ContactPoint
 
-    res = ADIWG::Mdtranslator::Writers::Dcat_us.startWriter(intMetadata, @@hResponse)
-    data = JSON.parse res
+    res = dcatusNS.build(intMetadata).target!
 
-    expected = JSON.parse '{"@type":"vcard:Contact", "fn":"test person test name", "hasEmail":"mailto:whatever@gmail.com"}'
-    assert_equal(expected, data['contactPoint'])
+    expected = '{"@type":"vcard:Contact","fn":"test person test name","hasEmail":"mailto:whatever@gmail.com"}'
+    assert_equal(expected, res)
   end
 
   def test_access_level

--- a/test/translator/tc_iso19115_3_to_dcatus.rb
+++ b/test/translator/tc_iso19115_3_to_dcatus.rb
@@ -111,7 +111,7 @@ class TestIso191153DcatusTranslation < Minitest::Test
     dcatusNS = ADIWG::Mdtranslator::Writers::Dcat_us::Publisher
     res = dcatusNS.build(@@intMetadata).target!
 
-    expected = '{"@type":"org:Organization","name":"U.S. Geological Survey, Alaska Science Center"}'
+    expected = '{"@type":"org:Organization","name":"U.S. Geological Survey - ScienceBase"}'
     assert_equal(expected, res)
   end
 

--- a/test/translator/testData/iso19115-2-datagov-to-dcatus.json
+++ b/test/translator/testData/iso19115-2-datagov-to-dcatus.json
@@ -6,7 +6,7 @@
   "modified": "2023-11-22T00:00:00+00:00",
   "publisher": {
     "@type": "org:Organization",
-    "name": "Office of National Marine Sanctuaries"
+    "name": "citation organization name"
   },
   "contactPoint": {
     "@type": "vcard:Contact",


### PR DESCRIPTION
related to [#5203](https://github.com/GSA/data.gov/issues/5203)

replace append of contact with hash in responsibility parties; rework contact point; fix tests and fixtures

- working through `contactPoint` i discovered I wasn't storing the correct data in the parties section of responsibility so this needed to change (store a party not a contact)
- `contactPoint` was refactored to handle our options more gracefully. this exposed a bug in retrieving the contact data via `Dcat_us.get_contact_by_id(contactId)` so this logic was substituted. frankly, i don't know why this change led to that function call failing but the replacement does what that function is supposed to do.
- publisher needed to be fixed a tad to properly handle the 2 options we try. there were poorly placed returns which messed things up.
- because contactPoint and publisher have changed i needed to update the associated tests/fixtures.