### PR TITLE
add more resource processing

### DIFF
--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
@@ -9,39 +9,57 @@ module ADIWG
       module Dcat_us
         module Distribution
           def self.build(intObj)
-            resourceDistributions = intObj.dig(:metadata, :distributorInfo)
-            distributions = []
+            resourceDistributions1 = intObj.dig(:metadata, :distributorInfo)
+            resourceDistributions2 = intObj.dig(:metadata, :associatedResources)
+            resourceDistributions3 = intObj.dig(:metadata, :resourceInfo, :keywords)
 
-            resourceDistributions&.each do |resource|
+            # gather up all our online resources from our options
+            onlineResources = []
+
+            resourceDistributions1&.each do |resource|
               resource[:distributor]&.each do |distributor|
                 distributor[:transferOptions]&.each do |transfer|
-                  # mediaType = MediaType.build(transfer)
-                  # TODO: change this when mediatype conversion works.
-                  # the mediatype needs to be set if there's a downloadURL
-                  mediaType = 'placeholder/value'
-
                   transfer[:onlineOptions]&.each do |option|
-                    next unless option[:olResURI]
-
-                    description = option[:olResDesc] || nil
-                    accessURL = AccessURL.build(option)
-                    downloadURL = DownloadURL.build(option)
-                    title = option[:olResName] || nil
-
-                    distribution = Jbuilder.new do |json|
-                      json.set!('@type', 'dcat:Distribution')
-                      json.set!('description', description)
-                      json.set!('accessURL', accessURL) if accessURL
-                      json.set!('downloadURL', downloadURL) if downloadURL
-                      json.set!('mediaType', mediaType)
-                      json.set!('title', title)
-                    end
-
-                    distributions << distribution.attributes!
-                    break
+                    onlineResources << option
                   end
                 end
               end
+            end
+
+            resourceDistributions2&.each do |resource|
+              onlineResources += resource[:resourceCitation][:onlineResources]
+            end
+
+            resourceDistributions3&.each do |resource|
+              onlineResources += resource[:thesaurus][:onlineResources]
+            end
+
+            onlineResources.uniq! # removes duplicates in-place
+
+            distributions = []
+
+            onlineResources&.each do |option|
+              # mediaType = MediaType.build(transfer)
+              # TODO: change this when mediatype conversion works.
+              # the mediatype needs to be set if there's a downloadURL
+              mediaType = 'placeholder/value'
+
+              next unless option[:olResURI]
+
+              description = option[:olResDesc] || nil
+              accessURL = AccessURL.build(option)
+              downloadURL = DownloadURL.build(option)
+              title = option[:olResName] || nil
+
+              distribution = Jbuilder.new do |json|
+                json.set!('@type', 'dcat:Distribution')
+                json.set!('description', description)
+                json.set!('accessURL', accessURL) if accessURL
+                json.set!('downloadURL', downloadURL) if downloadURL
+                json.set!('mediaType', mediaType)
+                json.set!('title', title)
+              end
+              distributions << distribution.attributes!
             end
             distributions
           end

--- a/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
+++ b/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
@@ -84,9 +84,19 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
 
     res = dcatusNS.build(intMetadata)
 
-    expected = [{ '@type' => 'dcat:Distribution', 'description' => 'online resource description',
-                  'downloadURL' => 'online resource URL', 'mediaType' => 'placeholder/value',
-                  'title' => 'online resource name' }]
+    expected = [
+      { '@type' => 'dcat:Distribution', 'description' => 'online resource description',
+        'downloadURL' => 'online resource URL', 'mediaType' => 'placeholder/value', 'title' => 'online resource name' },
+      { '@type' => 'dcat:Distribution', 'description' => 'aggregate information detailed description',
+        'downloadURL' => 'aggregate_information_online_resources', 'mediaType' => 'placeholder/value',
+        'title' => 'name of aggregate information resource' },
+      { '@type' => 'dcat:Distribution', 'description' => 'aggregate information detailed description aoisd',
+        'downloadURL' => 'aggregate_information_online_resources 12309u', 'mediaType' => 'placeholder/value',
+        'title' => 'name of aggregate information resource 10923j' },
+      { '@type' => 'dcat:Distribution', 'description' => 'Aggregation Info Sample Description',
+        'downloadURL' => 'https://aggregation_info_sample_url.gov', 'mediaType' => 'placeholder/value',
+        'title' => 'Aggregation Info Sample Name' }
+    ]
     assert_equal(expected, res)
   end
 

--- a/test/translator/tc_iso19115_3_to_dcatus.rb
+++ b/test/translator/tc_iso19115_3_to_dcatus.rb
@@ -145,7 +145,7 @@ class TestIso191153DcatusTranslation < Minitest::Test
 
     refute_empty res
     assert res.instance_of? Array
-    assert_equal(1, res.size)
+    assert_equal(7, res.size)
 
     dist = res[0]
     assert_equal('dcat:Distribution', dist['@type'])

--- a/test/translator/testData/iso19115-2-datagov-to-dcatus.json
+++ b/test/translator/testData/iso19115-2-datagov-to-dcatus.json
@@ -22,6 +22,27 @@
       "downloadURL": "online resource URL",
       "mediaType": "placeholder/value",
       "title": "online resource name"
+    },
+    {
+      "@type": "dcat:Distribution",
+      "description": "aggregate information detailed description",
+      "downloadURL": "aggregate_information_online_resources",
+      "mediaType": "placeholder/value",
+      "title": "name of aggregate information resource"
+    },
+    {
+      "@type": "dcat:Distribution",
+      "description": "aggregate information detailed description aoisd",
+      "downloadURL": "aggregate_information_online_resources 12309u",
+      "mediaType": "placeholder/value",
+      "title": "name of aggregate information resource 10923j"
+    },
+    {
+      "@type": "dcat:Distribution",
+      "description": "Aggregation Info Sample Description",
+      "downloadURL": "https://aggregation_info_sample_url.gov",
+      "mediaType": "placeholder/value",
+      "title": "Aggregation Info Sample Name"
     }
   ],
   "license": "https://creativecommons.org/publicdomain/zero/1.0/",

--- a/test/writers/dcat_us/tc_dcat_us_distribution.rb
+++ b/test/writers/dcat_us/tc_dcat_us_distribution.rb
@@ -19,8 +19,10 @@ class TestWriterDcatUsDistribution < TestWriterDcatUsParent
     expect = [
       { '@type' => 'dcat:Distribution', 'description' => 'distribution online resource description',
         'downloadURL' => 'http://ISO.uri/adiwg/0', 'mediaType' => 'placeholder/value' },
-      { '@type' => 'dcat:Distribution', 'description' => 'distribution description', 'downloadURL' =>
-        'http://ISO.uri/adiwg/3', 'mediaType' => 'placeholder/value' }
+      { '@type' => 'dcat:Distribution', 'downloadURL' => 'http://ISO.uri/adiwg/1',
+        'mediaType' => 'placeholder/value' },
+      { '@type' => 'dcat:Distribution', 'description' => 'distribution description',
+        'downloadURL' => 'http://ISO.uri/adiwg/3', 'mediaType' => 'placeholder/value' }
     ]
 
     assert_equal expect, got


### PR DESCRIPTION
related to [#5149](https://github.com/GSA/data.gov/issues/5149)

- this ended up being easier than i thought. we actually don't need to add more `gmd:identificationInfo` processing which is what i initially thought would be the case. instead, we just need the dcat_us writer to look in more places which is what's introduced in this PR. 
- the updates to tests clearly show we're getting more resources/distributions from the input doc. 
- the output of transformation from this catalog prod [doc](https://catalog.data.gov/dataset/noaa-monthly-u-s-climate-divisional-database-nclimdiv1) has 13 resources instead of 18. that's because there's 5 duplicates of "Global Change Master Directory (GCMD) Keywords". 