### PR TITLE
add more resource processing

### DIFF
--- a/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_iso19115_2.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_iso19115_2.rb
@@ -64,17 +64,10 @@ module ADIWG
           end
 
           # add new contact to contacts array
-          def self.add_contact(name, isOrg)
-            contactId = find_contact_by_name(name)
-            if contactId.nil?
-              intMetadataClass = InternalMetadata.new
-              hContact = intMetadataClass.newContact
-              contactId = UUIDTools::UUID.random_create.to_s
-              hContact[:contactId] = contactId
-              hContact[:name] = name
-              hContact[:isOrganization] = isOrg
-              @contacts << hContact
-            end
+          def self.add_contact(hContact)
+            contactId = UUIDTools::UUID.random_create.to_s
+            hContact[:contactId] = contactId
+            @contacts << hContact
             contactId
           end
 

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
@@ -12,6 +12,8 @@ module ADIWG
             resourceDistributions1 = intObj.dig(:metadata, :distributorInfo)
             resourceDistributions2 = intObj.dig(:metadata, :associatedResources)
             resourceDistributions3 = intObj.dig(:metadata, :resourceInfo, :keywords)
+            resourceDistributions4 = intObj.dig(:metadata, :resourceInfo, :citation)
+            resourceDistributions5 = intObj.dig(:metadata, :resourceInfo, :pointOfContacts, 0, :parties, 0)
 
             # gather up all our online resources from our options
             onlineResources = []
@@ -34,15 +36,22 @@ module ADIWG
               onlineResources += resource[:thesaurus][:onlineResources]
             end
 
-            onlineResources.uniq! # removes duplicates in-place
+            onlineResources += resourceDistributions4[:onlineResources]
+
+            unless resourceDistributions5.nil?
+              contact = intObj[:contacts].select { |c| c[:contactId] == resourceDistributions5[:contactId] }[0]
+              onlineResources += contact[:onlineResources]
+            end
+
+            # removes duplicates in-place by uri
+            onlineResources.uniq! { |onlineresource| onlineresource[:olResURI] }
 
             distributions = []
 
             onlineResources&.each do |option|
-              # mediaType = MediaType.build(transfer)
-              # TODO: change this when mediatype conversion works.
-              # the mediatype needs to be set if there's a downloadURL
-              mediaType = 'placeholder/value'
+              # we calculate the mediaType in the harvester
+              # because it's unreliable in the source
+              mediaType = nil
 
               next unless option[:olResURI]
 

--- a/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
+++ b/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
@@ -86,16 +86,18 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
 
     expected = [
       { '@type' => 'dcat:Distribution', 'description' => 'online resource description',
-        'downloadURL' => 'online resource URL', 'mediaType' => 'placeholder/value', 'title' => 'online resource name' },
+        'downloadURL' => 'online resource URL', 'title' => 'online resource name' },
       { '@type' => 'dcat:Distribution', 'description' => 'aggregate information detailed description',
-        'downloadURL' => 'aggregate_information_online_resources', 'mediaType' => 'placeholder/value',
+        'downloadURL' => 'aggregate_information_online_resources',
         'title' => 'name of aggregate information resource' },
       { '@type' => 'dcat:Distribution', 'description' => 'aggregate information detailed description aoisd',
-        'downloadURL' => 'aggregate_information_online_resources 12309u', 'mediaType' => 'placeholder/value',
+        'downloadURL' => 'aggregate_information_online_resources 12309u',
         'title' => 'name of aggregate information resource 10923j' },
       { '@type' => 'dcat:Distribution', 'description' => 'Aggregation Info Sample Description',
-        'downloadURL' => 'https://aggregation_info_sample_url.gov', 'mediaType' => 'placeholder/value',
-        'title' => 'Aggregation Info Sample Name' }
+        'downloadURL' => 'https://aggregation_info_sample_url.gov',
+        'title' => 'Aggregation Info Sample Name' },
+      { '@type' => 'dcat:Distribution', 'description' => 'online resource description',
+        'downloadURL' => 'https://online_resource_url.gov', 'title' => 'online resource name' }
     ]
     assert_equal(expected, res)
   end

--- a/test/translator/tc_iso19115_3_to_dcatus.rb
+++ b/test/translator/tc_iso19115_3_to_dcatus.rb
@@ -145,13 +145,12 @@ class TestIso191153DcatusTranslation < Minitest::Test
 
     refute_empty res
     assert res.instance_of? Array
-    assert_equal(7, res.size)
+    assert_equal(9, res.size)
 
     dist = res[0]
     assert_equal('dcat:Distribution', dist['@type'])
     assert_equal('description of the online resource via transfer options', dist['description'])
     assert_equal('https://distributiontransfer.com/onlineresource.png', dist['downloadURL'])
-    assert_equal('placeholder/value', dist['mediaType'])
     assert_equal('name test 123', dist['title'])
   end
 

--- a/test/translator/testData/iso19115-2-datagov-to-dcatus.json
+++ b/test/translator/testData/iso19115-2-datagov-to-dcatus.json
@@ -20,29 +20,31 @@
       "@type": "dcat:Distribution",
       "description": "online resource description",
       "downloadURL": "online resource URL",
-      "mediaType": "placeholder/value",
       "title": "online resource name"
     },
     {
       "@type": "dcat:Distribution",
       "description": "aggregate information detailed description",
       "downloadURL": "aggregate_information_online_resources",
-      "mediaType": "placeholder/value",
       "title": "name of aggregate information resource"
     },
     {
       "@type": "dcat:Distribution",
       "description": "aggregate information detailed description aoisd",
       "downloadURL": "aggregate_information_online_resources 12309u",
-      "mediaType": "placeholder/value",
       "title": "name of aggregate information resource 10923j"
     },
     {
       "@type": "dcat:Distribution",
       "description": "Aggregation Info Sample Description",
       "downloadURL": "https://aggregation_info_sample_url.gov",
-      "mediaType": "placeholder/value",
       "title": "Aggregation Info Sample Name"
+    },
+    {
+      "@type": "dcat:Distribution",
+      "description": "online resource description",
+      "downloadURL": "https://online_resource_url.gov",
+      "title": "online resource name"
     }
   ],
   "license": "https://creativecommons.org/publicdomain/zero/1.0/",

--- a/test/writers/dcat_us/tc_dcat_us_distribution.rb
+++ b/test/writers/dcat_us/tc_dcat_us_distribution.rb
@@ -18,11 +18,11 @@ class TestWriterDcatUsDistribution < TestWriterDcatUsParent
 
     expect = [
       { '@type' => 'dcat:Distribution', 'description' => 'distribution online resource description',
-        'downloadURL' => 'http://ISO.uri/adiwg/0', 'mediaType' => 'placeholder/value' },
-      { '@type' => 'dcat:Distribution', 'downloadURL' => 'http://ISO.uri/adiwg/1',
-        'mediaType' => 'placeholder/value' },
+        'downloadURL' => 'http://ISO.uri/adiwg/0' },
+      { '@type' => 'dcat:Distribution', 'downloadURL' => 'http://ISO.uri/adiwg/1' },
       { '@type' => 'dcat:Distribution', 'description' => 'distribution description',
-        'downloadURL' => 'http://ISO.uri/adiwg/3', 'mediaType' => 'placeholder/value' }
+        'downloadURL' => 'http://ISO.uri/adiwg/3' },
+      { '@type' => 'dcat:Distribution', 'downloadURL' => 'http://ISO.uri/adiwg/2' }
     ]
 
     assert_equal expect, got


### PR DESCRIPTION
related to [#5149](https://github.com/GSA/data.gov/issues/5149)

- remove mediatype placeholder and fix tests
- add more distribution options and fix tests
- minor fixes
  - it's common for contact names to be repeated across a document (it would be best if we consolidate these contacts based on name but that requires more thought and isn't necessary right now). because of the repeated name of contacts i had to change how we add contacts to not be dependent on whether the name already exists. we just want the thing added to the internal contacts array.
  - positionName shouldn't be used to determine whether a contact is an org or not

- you can see that we're getting more resource/distribution data based on the test updates.