### PR TITLE
add placeholder mediatype if downloadURL is present

### DIFF
--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
@@ -55,15 +55,16 @@ module ADIWG
             distributions = []
 
             onlineResources&.each do |option|
-              # we calculate the mediaType in the harvester
-              # because it's unreliable in the source
-              mediaType = nil
-
               next unless option[:olResURI]
 
               description = option[:olResDesc] || nil
               accessURL = AccessURL.build(option)
               downloadURL = DownloadURL.build(option)
+              # we calculate the mediaType in the harvester
+              # because it's unreliable in the source
+              # mediaType is required if downloadURL is present
+              mediaType = 'placeholder/value' if downloadURL
+
               title = option[:olResName] || nil
 
               distribution = Jbuilder.new do |json|

--- a/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
+++ b/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
@@ -86,18 +86,19 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
 
     expected = [
       { '@type' => 'dcat:Distribution', 'description' => 'online resource description',
-        'downloadURL' => 'online resource URL', 'title' => 'online resource name' },
+        'downloadURL' => 'online resource URL', 'title' => 'online resource name', 'mediaType' => 'placeholder/value' },
       { '@type' => 'dcat:Distribution', 'description' => 'aggregate information detailed description',
         'downloadURL' => 'aggregate_information_online_resources',
-        'title' => 'name of aggregate information resource' },
+        'title' => 'name of aggregate information resource', 'mediaType' => 'placeholder/value' },
       { '@type' => 'dcat:Distribution', 'description' => 'aggregate information detailed description aoisd',
         'downloadURL' => 'aggregate_information_online_resources 12309u',
-        'title' => 'name of aggregate information resource 10923j' },
+        'title' => 'name of aggregate information resource 10923j', 'mediaType' => 'placeholder/value' },
       { '@type' => 'dcat:Distribution', 'description' => 'Aggregation Info Sample Description',
         'downloadURL' => 'https://aggregation_info_sample_url.gov',
-        'title' => 'Aggregation Info Sample Name' },
+        'title' => 'Aggregation Info Sample Name', 'mediaType' => 'placeholder/value' },
       { '@type' => 'dcat:Distribution', 'description' => 'online resource description',
-        'downloadURL' => 'https://online_resource_url.gov', 'title' => 'online resource name' }
+        'downloadURL' => 'https://online_resource_url.gov', 'title' => 'online resource name',
+        'mediaType' => 'placeholder/value' }
     ]
     assert_equal(expected, res)
   end

--- a/test/translator/testData/iso19115-2-datagov-to-dcatus.json
+++ b/test/translator/testData/iso19115-2-datagov-to-dcatus.json
@@ -20,30 +20,35 @@
       "@type": "dcat:Distribution",
       "description": "online resource description",
       "downloadURL": "online resource URL",
+      "mediaType": "placeholder/value",
       "title": "online resource name"
     },
     {
       "@type": "dcat:Distribution",
       "description": "aggregate information detailed description",
       "downloadURL": "aggregate_information_online_resources",
+      "mediaType": "placeholder/value",
       "title": "name of aggregate information resource"
     },
     {
       "@type": "dcat:Distribution",
       "description": "aggregate information detailed description aoisd",
       "downloadURL": "aggregate_information_online_resources 12309u",
+      "mediaType": "placeholder/value",
       "title": "name of aggregate information resource 10923j"
     },
     {
       "@type": "dcat:Distribution",
       "description": "Aggregation Info Sample Description",
       "downloadURL": "https://aggregation_info_sample_url.gov",
+      "mediaType": "placeholder/value",
       "title": "Aggregation Info Sample Name"
     },
     {
       "@type": "dcat:Distribution",
       "description": "online resource description",
       "downloadURL": "https://online_resource_url.gov",
+      "mediaType": "placeholder/value",
       "title": "online resource name"
     }
   ],

--- a/test/writers/dcat_us/tc_dcat_us_distribution.rb
+++ b/test/writers/dcat_us/tc_dcat_us_distribution.rb
@@ -18,11 +18,13 @@ class TestWriterDcatUsDistribution < TestWriterDcatUsParent
 
     expect = [
       { '@type' => 'dcat:Distribution', 'description' => 'distribution online resource description',
-        'downloadURL' => 'http://ISO.uri/adiwg/0' },
-      { '@type' => 'dcat:Distribution', 'downloadURL' => 'http://ISO.uri/adiwg/1' },
+        'downloadURL' => 'http://ISO.uri/adiwg/0', 'mediaType' => 'placeholder/value' },
+      { '@type' => 'dcat:Distribution', 'downloadURL' => 'http://ISO.uri/adiwg/1',
+        'mediaType' => 'placeholder/value' },
       { '@type' => 'dcat:Distribution', 'description' => 'distribution description',
-        'downloadURL' => 'http://ISO.uri/adiwg/3' },
-      { '@type' => 'dcat:Distribution', 'downloadURL' => 'http://ISO.uri/adiwg/2' }
+        'downloadURL' => 'http://ISO.uri/adiwg/3', 'mediaType' => 'placeholder/value' },
+      { '@type' => 'dcat:Distribution', 'downloadURL' => 'http://ISO.uri/adiwg/2',
+        'mediaType' => 'placeholder/value' }
     ]
 
     assert_equal expect, got


### PR DESCRIPTION
related to [#5198](https://github.com/GSA/data.gov/issues/5198)

- i didn't know that if downloadURL is present then mediatype is required so adding the placeholder value back in and updating tests