### PR TITLE
bug fix

### DIFF
--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
@@ -29,7 +29,8 @@ module ADIWG
             end
 
             resourceDistributions2&.each do |resource|
-              onlineResources += resource[:resourceCitation][:onlineResources]
+              data = resource.dig(:resourceCitation, :onlineResources)
+              onlineResources += data unless data.nil?
             end
 
             resourceDistributions3&.each do |resource|


### PR DESCRIPTION
related to [5261](https://github.com/GSA/data.gov/issues/5261). testing against ioos and this [doc](https://data.noaa.gov/waf/NOAA/ioos/iso/xml/067-san-nicolas-island-ca-46219.xml) caused the issue. `dig` returns nil if the key access path doesn't exist so this change just appends the online resource if it's discoverable.