### PR TITLE
data sanitizing

### DIFF
--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_contact_point.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_contact_point.rb
@@ -32,6 +32,8 @@ module ADIWG
 
             return nil if fn.empty? | hasEmail.empty?
 
+            hasEmail = hasEmail.downcase.strip.gsub(/\s+/, '')
+
             # there's an email and it doesn't already start with "mailto:"
             hasEmail = "mailto:#{hasEmail}" if !hasEmail.nil? && (!hasEmail.start_with? 'mailto:')
 

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
@@ -61,8 +61,12 @@ module ADIWG
               next unless option[:olResURI]
 
               description = AdiwgUtils.empty_string_to_nil(option[:olResDesc])
-              accessURL = AccessURL.build(option)
-              downloadURL = DownloadURL.build(option)
+              accessURL = AdiwgUtils.empty_string_to_nil(AccessURL.build(option))
+              downloadURL = AdiwgUtils.empty_string_to_nil(DownloadURL.build(option))
+
+              # no point in creating a distribution if there's no link
+              next if accessURL.nil? && downloadURL.nil?
+
               # we calculate the mediaType in the harvester
               # because it's unreliable in the source
               # mediaType is required if downloadURL is present


### PR DESCRIPTION
all of these fixes address validation issues seen in dev 
- sanitizes the email: make all letters lowercase, removes [ \t\r\n\f] characters from it (relevant [job](https://datagov-harvest-dev.app.cloud.gov/harvest_job/577eacea-e2b6-410a-98c4-b9639b38afbf))
- skip distributions which don't have a link (accessURL and downloadURL).

