### PR TITLE
skip "None" emails

### DIFF
--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_contact_point.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_contact_point.rb
@@ -24,6 +24,8 @@ module ADIWG
               name = contact[:name]
               email = contact[:eMailList][0]
 
+              next if email == 'None'
+
               if !name.nil? && !email.nil?
                 fn = name
                 hasEmail = email


### PR DESCRIPTION
lots of instances like this in ioos. see [job](https://datagov-harvest-dev.app.cloud.gov/harvest_job/60b2a290-e65a-4096-b5f4-9d95b5fb2cc2). although this skips the contact with that email it may pick up another contact with invalid data so we're not necessarily getting more records but we probably are