### PR TITLE
read more distributions

### DIFF
--- a/lib/adiwg/mdtranslator/internal/module_utils.rb
+++ b/lib/adiwg/mdtranslator/internal/module_utils.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'net/http'
+require 'uri'
 
 module AdiwgUtils
   def self.reconcile_hashes(hashA, hashB)
@@ -133,5 +134,17 @@ module AdiwgUtils
     return nil if input.is_a?(String) && input.empty?
 
     input
+  end
+
+  def self.normalized_path(url)
+    # strips url query params and fragments for compatibility with File.extname
+    # URI.parse("https://example.com/file.pdf?x=1#top").path -> /file.pdf
+    # without it we have File.extname("https://example.com/file.pdf?download=1") -> .pdf?download=1
+    uri = URI.parse(url)
+    path = uri.path.to_s
+    path = '/' if path.empty?
+    path
+  rescue URI::InvalidURIError
+    ''
   end
 end

--- a/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_distribution.rb
+++ b/lib/adiwg/mdtranslator/readers/iso19115_2_datagov/modules/module_distribution.rb
@@ -39,22 +39,19 @@ module ADIWG
             # type="gmd:MD_DigitalTransferOptions_PropertyType"/>
             xTransfers = xDistribution.xpath(@@transferOptionsXPath)
             transferOptions = xTransfers.map { |t| Transfer.unpack(t, hResponseObj) }.compact
-            optionSize = transferOptions.size
 
+            # we're not doing anything with formats. we let the harvester determine the format.
             # : distributionFormats (optional)
             # <element maxOccurs="unbounded" minOccurs="0" name="distributionFormat"
             # type="gmd:MD_Format_PropertyType">
-            xDistFormat = xDistribution.xpath(@@distributionFormatXPath)
-            distributionFormats = xDistFormat.map { |f| Format.unpack(f, hResponseObj) }.compact
-            formatSize = distributionFormats.size
+            # xDistFormat = xDistribution.xpath(@@distributionFormatXPath)
+            # distributionFormats = xDistFormat.map { |f| Format.unpack(f, hResponseObj) }.compact
 
-            smallestArr = formatSize > optionSize ? transferOptions : distributionFormats
-
-            hDistribution[:distributor].each do |distributor|
-              (0...smallestArr.size).each do |idx|
-                distributor[:transferOptions][idx] = transferOptions[idx]
-                distributor[:transferOptions][idx][:distributionFormats] = [distributionFormats[idx]]
-              end
+            # distributors and certain distributions/resources are siblings. the internal md object
+            # doesn't support that. distributions need to be within a distributor so we're putting
+            # the distributions without a distributor within the first one
+            unless hDistribution[:distributor].empty?
+              hDistribution[:distributor][0][:transferOptions] += transferOptions
             end
 
             hDistribution

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_access_url.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_access_url.rb
@@ -1,17 +1,26 @@
 require 'jbuilder'
+require 'adiwg/mdtranslator/internal/module_utils'
+
+PAGE_EXTENSIONS = Set.new(%w[
+                            .html .htm .xhtml .php .asp .aspx .jsp .cfm
+                          ]).freeze
 
 module ADIWG
-   module Mdtranslator
-      module Writers
-         module Dcat_us
-            module AccessURL
+  module Mdtranslator
+    module Writers
+      module Dcat_us
+        module AccessURL
+          def self.access_url?(option)
+            path = AdiwgUtils.normalized_path(option[:olResURI])
+            ext = File.extname(path).downcase
 
-               def self.build(option)
-                  option[:olResURI] if option[:olResURI].end_with?('.html')
-                end                
+            # if the path ends with '/', or it doesn't have a file extension, or it has a common page extension
+            return true if path.end_with?('/') || ext.empty? || PAGE_EXTENSIONS.include?(ext)
 
-            end
-         end
+            false
+          end
+        end
       end
-   end
+    end
+  end
 end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_distribution.rb
@@ -61,24 +61,25 @@ module ADIWG
               next unless option[:olResURI]
 
               description = AdiwgUtils.empty_string_to_nil(option[:olResDesc])
-              accessURL = AdiwgUtils.empty_string_to_nil(AccessURL.build(option))
-              downloadURL = AdiwgUtils.empty_string_to_nil(DownloadURL.build(option))
+              accessURL = AccessURL.access_url?(option)
+              # if it's not a web page and it has a file extension then let's assume it's a downloadable file
+              downloadURL = DownloadURL.download_url?(option) unless accessURL
 
               # no point in creating a distribution if there's no link
-              next if accessURL.nil? && downloadURL.nil?
+              next unless accessURL || downloadURL
 
-              # we calculate the mediaType in the harvester
-              # because it's unreliable in the source
-              # mediaType is required if downloadURL is present
-              mediaType = 'placeholder/value' if downloadURL
+              # at this point one is true
+              linkData = accessURL ? ['accessURL', option[:olResURI]] : ['downloadURL', option[:olResURI]]
+
+              # if there's a downloadURL there has to be a mediaType in dcatus 1.1 so using a placeholder
+              mediaType = accessURL ? 'text/html' : 'placeholder/value'
 
               title = AdiwgUtils.empty_string_to_nil(option[:olResName])
 
               distribution = Jbuilder.new do |json|
                 json.set!('@type', 'dcat:Distribution')
                 json.set!('description', description)
-                json.set!('accessURL', accessURL) if accessURL
-                json.set!('downloadURL', downloadURL) if downloadURL
+                json.set!(*linkData)
                 json.set!('mediaType', mediaType)
                 json.set!('title', title)
               end

--- a/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_download_url.rb
+++ b/lib/adiwg/mdtranslator/writers/dcat_us/sections/dcat_us_download_url.rb
@@ -1,17 +1,18 @@
 require 'jbuilder'
+require 'adiwg/mdtranslator/internal/module_utils'
 
 module ADIWG
-   module Mdtranslator
-      module Writers
-         module Dcat_us
-            module DownloadURL
-
-               def self.build(option)
-                  option[:olResURI] unless option[:olResURI].end_with?('.html')
-                end                
-
-            end
-         end
+  module Mdtranslator
+    module Writers
+      module Dcat_us
+        module DownloadURL
+          def self.download_url?(option)
+            # avoid comparing the file extension to a limited set of values (e.g. .json, .xml, .rdf, etc...)
+            path = AdiwgUtils.normalized_path(option[:olResURI])
+            !File.extname(path).empty?
+          end
+        end
       end
-   end
+    end
+  end
 end

--- a/test/readers/iso19115_2_datagov/tc_iso19115_2_distribution.rb
+++ b/test/readers/iso19115_2_datagov/tc_iso19115_2_distribution.rb
@@ -20,6 +20,9 @@ class TestReaderIso191152datagovDistribution < TestReaderIso191152datagovParent
     refute_empty hDictionary
     assert hDictionary.instance_of? Hash
 
+    # the distributor has 1 distribution along with 1 sibling distribution
+    assert_equal(2, hDictionary.dig(:distributor, 0, :transferOptions).size)
+
     hTransferOptions = hDictionary.dig(:distributor, 0, :transferOptions, 0)
     hOnlineOptions = hTransferOptions.dig(:onlineOptions, 0)
     assert_equal('online resource URL', hOnlineOptions[:olResURI])

--- a/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
+++ b/test/translator/tc_iso19115_2_datagov_to_dcatus.rb
@@ -84,22 +84,20 @@ class TestIso191152datagovDcatusTranslation < Minitest::Test
 
     res = dcatusNS.build(intMetadata)
 
-    expected = [
-      { '@type' => 'dcat:Distribution', 'description' => 'online resource description',
-        'downloadURL' => 'online resource URL', 'title' => 'online resource name', 'mediaType' => 'placeholder/value' },
-      { '@type' => 'dcat:Distribution', 'description' => 'aggregate information detailed description',
-        'downloadURL' => 'aggregate_information_online_resources',
-        'title' => 'name of aggregate information resource', 'mediaType' => 'placeholder/value' },
-      { '@type' => 'dcat:Distribution', 'description' => 'aggregate information detailed description aoisd',
-        'downloadURL' => 'aggregate_information_online_resources 12309u',
-        'title' => 'name of aggregate information resource 10923j', 'mediaType' => 'placeholder/value' },
-      { '@type' => 'dcat:Distribution', 'description' => 'Aggregation Info Sample Description',
-        'downloadURL' => 'https://aggregation_info_sample_url.gov',
-        'title' => 'Aggregation Info Sample Name', 'mediaType' => 'placeholder/value' },
-      { '@type' => 'dcat:Distribution',
-        'downloadURL' => 'https://online_resource_url.gov', 'title' => 'online resource name',
-        'mediaType' => 'placeholder/value' }
-    ]
+    expected = [{ '@type' => 'dcat:Distribution', 'description' => 'online resource description',
+                  'accessURL' => 'online resource URL', 'mediaType' => 'text/html', 'title' => 'online resource name' },
+                { '@type' => 'dcat:Distribution', 'description' => 'aggregate information detailed description',
+                  'accessURL' => 'aggregate_information_online_resources', 'mediaType' => 'text/html',
+                  'title' => 'name of aggregate information resource' },
+                { '@type' => 'dcat:Distribution', 'description' => 'aggregate information detailed description aoisd',
+                  'accessURL' => 'aggregate_information_online_resources 12309u', 'mediaType' => 'text/html',
+                  'title' => 'name of aggregate information resource 10923j' },
+                { '@type' => 'dcat:Distribution', 'description' => 'Aggregation Info Sample Description',
+                  'accessURL' => 'https://aggregation_info_sample_url.gov', 'mediaType' => 'text/html',
+                  'title' => 'Aggregation Info Sample Name' },
+                { '@type' => 'dcat:Distribution', 'accessURL' => 'https://online_resource_url.gov',
+                  'mediaType' => 'text/html',
+                  'title' => 'online resource name' }]
     assert_equal(expected, res)
   end
 

--- a/test/translator/testData/iso19115-2-datagov-to-dcatus.json
+++ b/test/translator/testData/iso19115-2-datagov-to-dcatus.json
@@ -19,35 +19,35 @@
     {
       "@type": "dcat:Distribution",
       "description": "online resource description",
-      "downloadURL": "online resource URL",
-      "mediaType": "placeholder/value",
+      "accessURL": "online resource URL",
+      "mediaType": "text/html",
       "title": "online resource name"
     },
     {
       "@type": "dcat:Distribution",
       "description": "aggregate information detailed description",
-      "downloadURL": "aggregate_information_online_resources",
-      "mediaType": "placeholder/value",
+      "accessURL": "aggregate_information_online_resources",
+      "mediaType": "text/html",
       "title": "name of aggregate information resource"
     },
     {
       "@type": "dcat:Distribution",
       "description": "aggregate information detailed description aoisd",
-      "downloadURL": "aggregate_information_online_resources 12309u",
-      "mediaType": "placeholder/value",
+      "accessURL": "aggregate_information_online_resources 12309u",
+      "mediaType": "text/html",
       "title": "name of aggregate information resource 10923j"
     },
     {
       "@type": "dcat:Distribution",
       "description": "Aggregation Info Sample Description",
-      "downloadURL": "https://aggregation_info_sample_url.gov",
-      "mediaType": "placeholder/value",
+      "accessURL": "https://aggregation_info_sample_url.gov",
+      "mediaType": "text/html",
       "title": "Aggregation Info Sample Name"
     },
     {
       "@type": "dcat:Distribution",
-      "downloadURL": "https://online_resource_url.gov",
-      "mediaType": "placeholder/value",
+      "accessURL": "https://online_resource_url.gov",
+      "mediaType": "text/html",
       "title": "online resource name"
     }
   ],

--- a/test/writers/dcat_us/tc_dcat_us_distribution.rb
+++ b/test/writers/dcat_us/tc_dcat_us_distribution.rb
@@ -16,16 +16,12 @@ class TestWriterDcatUsDistribution < TestWriterDcatUsParent
     hJsonOut = JSON.parse(metadata[:writerOutput])
     got = hJsonOut['distribution']
 
-    expect = [
-      { '@type' => 'dcat:Distribution', 'description' => 'distribution online resource description',
-        'downloadURL' => 'http://ISO.uri/adiwg/0', 'mediaType' => 'placeholder/value' },
-      { '@type' => 'dcat:Distribution', 'downloadURL' => 'http://ISO.uri/adiwg/1',
-        'mediaType' => 'placeholder/value' },
-      { '@type' => 'dcat:Distribution', 'description' => 'distribution description',
-        'downloadURL' => 'http://ISO.uri/adiwg/3', 'mediaType' => 'placeholder/value' },
-      { '@type' => 'dcat:Distribution', 'downloadURL' => 'http://ISO.uri/adiwg/2',
-        'mediaType' => 'placeholder/value' }
-    ]
+    expect = [{ '@type' => 'dcat:Distribution', 'description' => 'distribution online resource description',
+                'accessURL' => 'http://ISO.uri/adiwg/0', 'mediaType' => 'text/html' },
+              { '@type' => 'dcat:Distribution', 'accessURL' => 'http://ISO.uri/adiwg/1', 'mediaType' => 'text/html' },
+              { '@type' => 'dcat:Distribution', 'description' => 'distribution description', 'accessURL' => 'http://ISO.uri/adiwg/3',
+                'mediaType' => 'text/html' },
+              { '@type' => 'dcat:Distribution', 'accessURL' => 'http://ISO.uri/adiwg/2', 'mediaType' => 'text/html' }]
 
     assert_equal expect, got
   end


### PR DESCRIPTION
related to [5767](https://github.com/GSA/data.gov/issues/5767)

- no longer limits resources/distributions based on available formats. this grabs all available ones within the expected context.
- also fixes a bug which could produce duplicate resources (i haven't seen this happen but this is a good fix nevertheless)
- there's a possibility for resources to be excluded if there's no distributor (it's an optional element in the source) see below.

```xml
<gmd:MD_Distribution>
  <!-- no distributor element --> 
  <gmd:transferOptions> 
    <!-- ... --> 
  </gmd:transferOptions>
</gmd:MD_Distribution>
```

in this ^ circumstance there's a resource/distribution but because there's no distributor and the internal md object doesn't support distributor-less distributions this would return 0 resources. in my entire time of working on mdtranslator i've never had to update the internal md object so i want to avoid that as much as possible. if there's lots of documents in this scenario then i suppose we could create a dummy distributor to put the resources into but I would encourage the data provider to include one instead.


### accessURL & downloadURL
the main purpose of this PR is to bring in more distributions but while i'm also bringing back mimetype calculation in harvester I decided to correct how we process `accessURL` and `downloadURL`. the logic for determining those fields isn't accurate. for example, an arcgis map server distribution/resource with a link `https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_Current/MapServer` would be considered a downloadURL but on ckan catalog it's a web page. this [noaa dataset on beta](https://catalog-beta.data.gov/dataset/u-s-billion-dollar-weather-and-climate-disasters-1980-present-ncei-accession-0209268) has 14 resources as downloadable files. that's incorrect. they should be web pages to visit. this PR fixes that.